### PR TITLE
customize indexing with exclusion patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    target-branch: "main"
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: "main"
+    schedule:
+      interval: weekly

--- a/bom/bom.json
+++ b/bom/bom.json
@@ -1,0 +1,5772 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "serialNumber" : "urn:uuid:8afeb254-6f6d-3499-96b3-f208d9ff798d",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2025-07-17T17:04:39Z",
+    "lifecycles" : [
+      {
+        "phase" : "build"
+      }
+    ],
+    "tools" : {
+      "components" : [
+        {
+          "type" : "library",
+          "author" : "OWASP Foundation",
+          "group" : "org.cyclonedx",
+          "name" : "cyclonedx-maven-plugin",
+          "version" : "2.9.1",
+          "description" : "CycloneDX Maven plugin",
+          "hashes" : [
+            {
+              "alg" : "MD5",
+              "content" : "9c7a565cf28cce58557d0c621c5ea4b1"
+            },
+            {
+              "alg" : "SHA-1",
+              "content" : "be882d5a22050bfa9d19090b1420c188617d0e1c"
+            },
+            {
+              "alg" : "SHA-256",
+              "content" : "698e0f37184a5b28c245c4065fd036dfce253b52f82fbb7113d81d36326cc249"
+            },
+            {
+              "alg" : "SHA-512",
+              "content" : "c0f0b11026858166f872a2eb54719492e5cecaa0bc9cd6b30b3ecb4a174eed220f4a1b5829d18d6734128e778d3cb3db7ffed177c92866133129cb29081814a0"
+            },
+            {
+              "alg" : "SHA-384",
+              "content" : "d80964707dfe5caca8c70521d5066f57589304c0a657e6fbc7c0614ea0fc7b3b3dbe7778361eee0f54ba111e9cb0ffcb"
+            },
+            {
+              "alg" : "SHA3-384",
+              "content" : "80bc3a275d9514bc457461ff52a72add8c7ecbbc01d8912efce57139016c544ee776981851be0a58fa977ab4221f703f"
+            },
+            {
+              "alg" : "SHA3-256",
+              "content" : "142317d6f245390f4fd2d0c100b16281b8dfc5c0c2cff86943bdcc97039cb699"
+            },
+            {
+              "alg" : "SHA3-512",
+              "content" : "af0fb9137c90b65d1a07f72e4d51ae509956cdb8800f35c961b037cdda1fe4a14ce3b496cef71ba85f1621affcfe29cd42704ae4191ff0b090a9602087c8997b"
+            }
+          ]
+        }
+      ]
+    },
+    "component" : {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.pqca/cbomkit-lib@1.0.0?type=jar",
+      "group" : "org.pqca",
+      "name" : "cbomkit-lib",
+      "version" : "1.0.0",
+      "purl" : "pkg:maven/org.pqca/cbomkit-lib@1.0.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution-intake",
+          "url" : "https://maven.pkg.github.com/PQCA/cbomkit-lib"
+        }
+      ]
+    },
+    "properties" : [
+      {
+        "name" : "maven.goal",
+        "value" : "makeAggregateBom"
+      },
+      {
+        "name" : "maven.scopes",
+        "value" : "compile,provided,runtime,system"
+      }
+    ]
+  },
+  "components" : [
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@3.0.0?type=jar",
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.annotation",
+      "name" : "jakarta.annotation-api",
+      "version" : "3.0.0",
+      "description" : "Jakarta Annotations API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7faffaab962918da4cf5ddfd76609dd2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "54f928fadec906a99d558536756d171917b9d936"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b01f55552284cfb149411e64eabca75e942d26d2e1786b32914250e4330afaa2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2bd5a16684c4e8144897ba6dc467628d1b8a85326235240e4c20101b6df3681d23aeebc30ca99e395ec848f33cb5244085031b2a0fbce746c8ede7148a5e7c1d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1a12cb78019d310eb08314f863c2a0e48aa2845bde844f8204e653ec50713bf135cc58cce882e14ef631327952b5ad99"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a0dd7dd32e8dc5ed679589f6066f16593b52334b9947a71381aeab44b3cbe295ec24dfef4fbfa5514ba24ea60fe042a9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6ae915a05b483f75c51f3a109cf368842d186b2996758b8a106377a7a9485c12"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "52f611aa0a98812e525be2b9d5a5712aef660598cff64282dbd9afc237560f442ab745fc95c919216f9cb4197c224ba6c7317282962c638fee956925bfa031c0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@3.0.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j.ca"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/jakartaee/common-annotations-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/ca-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jakartaee/common-annotations-api"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.slf4j/slf4j-simple@2.0.17?type=jar",
+      "publisher" : "QOS.ch",
+      "group" : "org.slf4j",
+      "name" : "slf4j-simple",
+      "version" : "2.0.17",
+      "description" : "SLF4J Simple Provider",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "47a7060262b6800b3e0e41db00909b81"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9872a3fd794ffe7b18d17747926a64d61526ca96"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ddfea59ac074c6d3e24ac2c38622d2d963895e17f70b38ed4bdae4d780be6964"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "99d594ec1d3ca7c909166de22e09b857358f1e8aeec2338d615d0d25b8116d51fe510554ce3be204e90fce392ecb9080afbc0b1f1a3ddcd186c3ab160abe47f0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b546b2ecc8f7c6ae368858bd0544b54a27c90d4561adebaba2f3abe66cce8e23ab6b0cd23340fd19e70724c7e7439b7b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ad8c31599f8284f9d739dc25c3bda0fc4de93bc639ac7d6777bcfd48eaf372d715ae05c2cb1be005e1c6f24c63b4a4e0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e1985f3d12b67d7347e5e97f4b1282d147be014627a7004b096868217d27a932"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0eda10e283ef72b0cc0a59c9b5ce6110d696b15e39fd05fee9c271c9bc405ffd9d8a10b6b58f6a279f3cd889dc62ee15ece338fd45fb5b09a0a86173158b3b11"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/license/mit/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.slf4j/slf4j-simple@2.0.17?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.slf4j.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/slf4j/slf4j-parent/slf4j-simple"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.slf4j/slf4j-api@2.0.17?type=jar",
+      "publisher" : "QOS.ch",
+      "group" : "org.slf4j",
+      "name" : "slf4j-api",
+      "version" : "2.0.17",
+      "description" : "The slf4j API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b6480d114a23683498ac3f746f959d2f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d9e58ac9c7779ba3bf8142aff6c830617a7fe60f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7b751d952061954d5abfed7181c1f645d336091b679891591d63329c622eb832"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9a3e79db6666a6096a3021bb2e1d918f30f589d8de51d6b600f8ebd92515a510ae2d8f87919cc2dfa8365d64f10194cac8dfa0fb950160eef0e9da06f6caaeb9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6ea24f814a9b6ece428cfd0535e2f3b8927005745ef61006b50fdb5a90126ee5ea05650155382b3b755c5bce38ef3944"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9b1015052f0ec43f9be09764e131834157599611cb52f6fe591c4ac6a8ab4817518f2a4b8871e5e738c8678e93af5557"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "00559b4f4066b4917ba4fe2a6f23111eaeada321112d030910d218ced9084b5e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9579c2f7e7516e177c2d493ccc9eb8150978cf19f6f09b28d116f6935239fd56dc6af2b62b3336f79b0b462445550cd1fb5377a07001a6f44aaab6a32fa2fa47"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/license/mit/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.slf4j/slf4j-api@2.0.17?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.slf4j.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/slf4j/slf4j-parent/slf4j-api"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ibm/sonar-cryptography-plugin@1.4.5?type=jar",
+      "group" : "com.ibm",
+      "name" : "sonar-cryptography-plugin",
+      "version" : "1.4.5",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c01151ef49a904f8bef5afb1a1a6fc48"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0538cca26f8ea1f174efaf6491ffcf030431b668"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c485dd72a58ae7c0946d6a911557614f0db554d8ec6b5060f7967b291ef746af"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f9585fd77952542f90d6c21fc17d195311f75be82ab0ff495e55e4cd8f4db745f1d31fbd0c457b9e706b87871f0e30c50fc03c942170452ddc4a737b613526c8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6a0fe0dd69277e645c1878407f9efb58cd2531a97909bf39695caab83fbd31c95deab65ee072d3ea0026853d4f3793de"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "03d1180c442177c290b578cae2f2977a156af908311f82037bb173a039e74bf072777384ba84c3691c1bac78b04921b7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b146940059b479778f205f403ad64dca24cc37c9189997feeaaadfc7935dc6a5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "09521d71403ff8c49a33c9fb57be1783ab1c63921649ad53a6e206fe79ee8e1fcde0e48a7cf471d73586ea7adef6691e46bea2ad4fc80341591e0c2ed7ca8c50"
+        }
+      ],
+      "purl" : "pkg:maven/com.ibm/sonar-cryptography-plugin@1.4.5?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ibm/java@1.4.5?type=jar",
+      "group" : "com.ibm",
+      "name" : "java",
+      "version" : "1.4.5",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e2e7c70b212d12d817a37cfc6295170c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c911806cd855579396a0534f87f601715142a469"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b407b3caca0343422229fe4f1f82f7f658309b5be19040cc5d31a0b5748eca2d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5cf5d56bdfabb5617eecf48d9436f13dbc1c06376f39fa01ce874c36a79467a43b94ec43ee184e3400be5b432a774498cbb7defa28e3f3e0d846a42a34277a47"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "648662fa795e988f3100416702e2ca672b12299035ec60a826bf15de7a2ffef597528d54939e3b2b50056e478f7e1b3d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "29fd73d932b0c25426a0c808dcb15404629b993e9c97ba0375c630a8e5b66ae3ec2db5c9c0b4d3455ec97039d27cbc74"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0feead0abf02297cf4255ffb95e93d16fb130bea2264489946da472b16d1ce93"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "73c14d2d73bdcf2c10c8f4d66afd65d73f4dfba6a79ffcb55c948960cae30e3db9e1b7efcc08fe5d0025222813f13070dd701389974ab3a0985539b9ae713881"
+        }
+      ],
+      "purl" : "pkg:maven/com.ibm/java@1.4.5?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ibm/engine@1.4.5?type=jar",
+      "group" : "com.ibm",
+      "name" : "engine",
+      "version" : "1.4.5",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3536b898d67c94fad1d7c1ee98e66eb8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "264f769fab030a78fc3bb766ef74a277905d4a09"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d5c7530540ce3eb20cb072413c6452db87faa28c977359436893e87f12c36d64"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d2345503f826658786f831ace0b21b616d4a89e584993c809d884e0d6f87e31ccf14506ef5e29ebe6dec1938b274d41ab4b97c60eb3e311ecce9dd9e3c545a1a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8d47cba45440c1d2e79ec7ac968d0ea2f4bc253c607102c0991c94e5fa16af883bd2a89f8c714c48002fed58340a4696"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "165379e9e820ddda326ce4e22483ac8f2ab278b886f37c2f318109a00897d83e0ad47b98b79856172e2690991561da46"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7ba492bc99093677e8f8352326bf617dfd9f182a68720dd41e9c6d9aace34568"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b2c5f5288c276bf802906549cde2ce670d8bab14e8cb220516bf57567d5111602e6532edd65a811144a4a01d36080fac3044695550bc21653fbb56c75f156bb7"
+        }
+      ],
+      "purl" : "pkg:maven/com.ibm/engine@1.4.5?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ibm/common@1.4.5?type=jar",
+      "group" : "com.ibm",
+      "name" : "common",
+      "version" : "1.4.5",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6501dcb9d7d4560e035134f9d347b4d4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "63e03d915f535df55450011b4fba4f3141685833"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0a6bdb5692ffaf9e691f356c11f86448614e36c361ffdc5b4003ee30d912c70b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f88fc417cd2a5a87705f1c4fcc0db40c8beb771897e38e54b309760fc95e0da48738ffc6b40b335770928dabfebc3a1e177790a48fa94bbfd46836f58d8737f4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "907ec1ace4ff6abfd960f184e7303cbe59d1c6cfc04449b7c3fdce7a7b961d45a30ded71061733967080785827bd7d21"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "93dcfe95d00f35e67fe2f0880bb7f45fbab706cd4a0ef54b5c08a23188f4cf87fa842998ddf56c8c776368d73cf745ce"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "05d3023458fe89d3422c817d0fe6fa46d6302195f2323f18c991241b7de73aea"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f0141992d1fed95a9faf150942ad1fcada41017ec293f6d50f2ca102884e290eb79ae05ae3373850b8dffbb7e9b789a24134589c9e4499d56203bd28a2257c0e"
+        }
+      ],
+      "purl" : "pkg:maven/com.ibm/common@1.4.5?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ibm/output@1.4.5?type=jar",
+      "group" : "com.ibm",
+      "name" : "output",
+      "version" : "1.4.5",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c63252e1e12830f9f560e0bd7f7ea35a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5c825f6bb9e6f22741d715b47e0f91b32be27f9c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7b406965a4a9799243fa6a8a97cca2412b196dcfaa93fe37ae23892ffd6a5743"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "55338664a17f1b4df9614cdad886c1c168087e3f188ea5c486def6bce0dca981b17efd9b9ffd5fbdd915aec16c7569e8d7444e6f46c0de185b83793c13cf5d7f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "580594f41df52dc089163460fc623c943a46439411df7eebb8d4790cb858f90dc884bf755a8fb3811d7501c8d4e44cde"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e1650094bb2d4cb380b342df7aa9897b38baf4204b453774550fdcb283b9b50a164cf65e0e58ca244d2f04562b3b4f94"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "712e660cdf29dcf4b6ffc6728ff61192622f198299a33eb50c601d507f40263f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d84f764200078e0dcc414c78f4582c3c5494751cdd7e89948bb5c12e34249d748550c572c6fd29ff69cfeab073a85ba34b85f17e14eede6a69af76fb9918f6e7"
+        }
+      ],
+      "purl" : "pkg:maven/com.ibm/output@1.4.5?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@10.1.0?type=jar",
+      "publisher" : "OWASP Foundation",
+      "group" : "org.cyclonedx",
+      "name" : "cyclonedx-core-java",
+      "version" : "10.1.0",
+      "description" : "The CycloneDX core module provides a model representation of the BOM along with utilities to assist in creating, parsing, and validating BOMs.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "26fb8feac89e11e64c3e8e8ce41c2b7a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7a557068d90721cb73b4561b09f31f32a1e22dda"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4931d0aed28763ae9fa1c574e26b7636879abdc101ff81ce3c63ad905c99937c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d92bfb20a866f44cf1ea771bb5f7c41ee87f13db26e7d77bcd63a910745b4a79f1d5661dfec621891e41cba573e524ca3a759e8a1bc1568a41bd6525c1d4fbbe"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7ee527f84ff6d68addbf0b54b7b0ae4d0e67eca8e16495355136186b92d2db9bb219365436a29eae73db6b5c2afd270a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "87cb89f356b2ddd6b1d055b5d7ffebf6de91c2080e88f16b5be35c8807669814d1ecb39aff3ca1bc40a397c4a4b6cd94"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6533ae5b9c185f185987e1005a3373ef82b84c07a76b571c6ae4b73f4a968d8d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "12d41199cb48270344a771ad54aab4f4764fce672cb657bb8d20f363c998a669f04a49efa032f1a1f024adc1b090e5328ce387644d0db67010bf578036663737"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@10.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-collections4",
+      "version" : "4.4",
+      "description" : "The Apache Commons Collections package contains types that extend and augment the Java Collections Framework.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4a37023740719b391f10030362c86be6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "62ebe7544cb7164d87e0637a2a6a2bdc981395e8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1df8b9430b5c8ed143d7815e403e33ef5371b2400aadbe9bda0883762e0846d1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5939c9931eb9557caee3b45fe1dd9ce54cabdc4e6182ed7faac77e1a866dd0cb602bfa4ece2f3316d769913366106bd2b61bf3bb5faad1fa7d808124c06dec0f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "74059fd8f61c366ed448e102256fdbd1db0d690501c2c296c80f3657a2c0d8ade3dd9533b1431cc29786bbb624195f46"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "15034fb39842620bf3b152cd90bce252644ebc6a29fafd6dcf5e1f3925f09ccea2ae4e195817450f996b25a7081a9a3f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1716630a207a8f4a83bf9ef19245f46c87d62bfebbcfa1227101e6dd51da8fa5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c290c98c7b5825d024644ec1162804a1f9ad4da3bb5324d147ddffee6cc79e3c0ecc3825d6116502f2ca292ec80c4e7f8d49a03542dda8f4d58b0dc8228923c5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-collections/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/COLLECTIONS"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://git-wip-us.apache.org/repos/asf?p=commons-collections.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar",
+      "group" : "com.github.package-url",
+      "name" : "packageurl-java",
+      "version" : "1.5.0",
+      "description" : "The official Java implementation of the PackageURL specification. PackageURL (purl) is a minimal specification for describing a package via a \"mostly universal\" URL.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "90856d8bb5b17e08fdf03b6a2f93b81c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e6bf530f52feab911f4032604ca0b8216f7ff337"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e45551727707acc0c56ac62d56964332ea0f138d6cc3656d988b9369150f5247"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8064df400154caa110b8845bd17e6cea2683307e575ce88e40d7c0c8965ea0af6c150a376d8b9ba7354676c41b52c94535f30c6e830447613299ccf5fc7aa959"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0597100022f72e020c9d929bf57ecef91af7574610fb03b4019feba4b25f491a076f03577be2009e66d9001c4c0f8ab0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bbdd55a31a4755ef589bcb176283fe03e3c9089d315eab577fef3a9c2d02e632c6ac3fdebbc90a2f0f8ed7974b9f397c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c9881b69bde35ea6ff4006877b9fbf91462f911b5b142aa699a45a00867d413a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2b9caf58deef687a9bf01abd61a7af4abdb61247a8a966683a18157ee948f1ea424602598dc8f665bf24f7e1e516866298ef0507e9d697cb20dcf60eff2095ca"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/license/mit/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/package-url/packageurl-java"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.com/package-url/packageurl-java"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/package-url/packageurl-java/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/package-url/packageurl-java.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.dataformat",
+      "name" : "jackson-dataformat-xml",
+      "version" : "2.18.2",
+      "description" : "Data format extension for Jackson to offer alternative support for serializing POJOs as XML and deserializing XML as pojos.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5aa50d2b48ea710b8844ba9367efd25d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "069cb3b7bd34b3f7842cc4a6fd717981433bf73e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3a5c26f070b9974617f4b103b9561d4f5e3f4f8cc60162d4e0cd3e172c776af5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "598f8f899a98b54da430f0e3ae71f8f46f0f6ffe5d1b5830db5609a31898e68be1954162cd8fce37e257d2455ba8ea0548334f8d0f10178aaaf1d02a1e359138"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1212410a2747ffa75d1a6e6343876b3ed1a45e21d2941c9058c7ef1f47935d4c02f9609a103a47e4ba5c39b93b12d2bb"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "81fa6f5f86e9c3cfda740acb5e257352a756721dae208692fce04575649e8019b381d215958eefabdede7cf4b358469d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "169047c6461509cf7a87df9a29b2f57501c5e5ff58290ce6e0bf0da6f0bf9f4e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b4ea2a395d883b9a367f24a47e1eabf03c398cf362d1493fedcaf61b1397092b8d70b51ad3d613759c0a73116d60f8b039c62f999ae503600974d3cb97fb48d2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-dataformat-xml"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-dataformat-xml/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-dataformat-xml"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.networknt/json-schema-validator@1.5.4?type=jar",
+      "group" : "com.networknt",
+      "name" : "json-schema-validator",
+      "version" : "1.5.4",
+      "description" : "A json schema validator that supports draft v4, v6, v7, v2019-09 and v2020-12",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "98778fbb12193b995880f2d38527c384"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "db9218932bada0485e137b86e25ce2b360ff8bf6"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fbbf8940c1a4c210dd58d1b7250420b32fa164bdbf31c3b077641327bd37faf6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b4dff88540d64b9a071c1b56658b056c11ebe7ab968ac8d1f8ed79d779dd13a9465f50b86bb0bc93b869d5a01af817cf227fa6a69d0ee53b866149b8d431b92f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "519fab4ab3677702ed33ae65ac5c61403e81f47e82c69acdac1c0c0db7bb5b84e75e98561ce928fa582e8fe62b75a293"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bec765fd0ccffee15d469dc353f8ad7b92b325b7674a2f30b6af98ec34905606051e6fe9ea696a61bb418a5bab2a014a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "200b1df5b38a69fdf6487c1235fe392ec77fee2fd9ea67a61662670424fce8c8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6bdae28e54676f792ffeecef96364654a866a41df49a0ccc055ea4a7767ca2877c1b4cc36fccc1de691649a3bcb805d8c43d35c46d16be353d8c5ec9c6a15f14"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.networknt/json-schema-validator@1.5.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/networknt/json-schema-validator"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/networknt/json-schema-validator/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/networknt/json-schema-validator.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ethlo.time/itu@1.10.2?type=jar",
+      "group" : "com.ethlo.time",
+      "name" : "itu",
+      "version" : "1.10.2",
+      "description" : "Extremely fast date-time parser and formatter - RFC 3339 (ISO 8601 profile) and W3C format",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1b839463605516af5fb01749a818e27b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "320413cc72bbcaddf543826909140f2ee9afe76f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0424b2ff0c20265a084a32a4907521b28e7b86af25d131987a6b31ef63b9687c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cd109e39af788d88543f0867fff48adefe23b01a77b4a5f1963b117b125b71c9613ba3009f69d8f1131f5066689e3f43457cc2a8f02e827f40502b5e13bc3794"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2411434f4e66f288d86fe37039ef1017adb28ee0996f8836a86571c547f6351561e127a49309a336bcdd5423b99cd2c8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4d33f9a2d525d0e3778c68526ef75a141a239e24a396b4456afc6fbb742415e7c801b1f8b4582fa26664b54bd69e217d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "887b21b9dd007248b77ef52db5dff20dc2cdf4728b6aaac32b6612bf1952f118"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b3ee4789007071421545ac04b51263946d5131787cc62bf2994b6fbace70dc10211f0382f4d0d4eb6df8e2b7da5f93782fe005fbab8e6352ef906819958ec80f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.ethlo.time/itu@1.10.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/ethlo/itu"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com:ethlo/itu"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.18.1?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.dataformat",
+      "name" : "jackson-dataformat-yaml",
+      "version" : "2.18.1",
+      "description" : "Support for reading and writing YAML-encoded data via Jackson abstractions.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "eb5387d4d9c396cfefe693d8972c2dde"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "71bf4432cc97bb989b3d5356a96aa2efdaa26d74"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b764452d6cdd644666bba2da35ef8e6dfb86b7a59d24d1d98ea2fcf1e6bb08b2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "048a63e6733d01f3deb4960ec90d0ae47db76620420d3466e8b20e825f4ffe59ad34091f83c6e0cd1223d440ac665367e445ce4288b2306f6692fde0271eee76"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "085e2a052aafdca2cf1e3d25d317ea314a6bed273aaa2853c994c3274cda701b51214cc9e8e78de467b06a66e6b9e4f7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3bf21caaf785472a974dfc3d40d3c1bba24537145d63e38874080e1578ea8d82235abae59fcfc4683cf4aeb6ad17bb86"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bdc3310c0c3f182e4221ceb0912bfb9718f1b638966f76c51abeec3c62ded590"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2af07aa68350ab0da96d3805ad8016c78a9cd759d98b1c9ec87613b263c77899296301a5faac9596e25ce7fd38de1c36e46f3717fcd6cca770ca2b2454d1abce"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.18.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-dataformats-text"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-dataformats-text/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/jackson-dataformats-text/jackson-dataformat-yaml"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.yaml/snakeyaml@2.3?type=jar",
+      "group" : "org.yaml",
+      "name" : "snakeyaml",
+      "version" : "2.3",
+      "description" : "YAML 1.1 parser and emitter for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2a1c2ee8923dcd6bd6d025751af5df37"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "936b36210e27320f920536f695cf1af210c44586"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "63a76fe66b652360bd4c2c107e6f0258daa7d4bb492008ba8c26fcd230ff9146"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1c9c78f0d102ae49a7c06f9e20c6a79a4fb9a2af962230ee6e136bda0caf10dcbb9deadc1c3ab15f74a4982ec8f8266217115e357329fde5b3f4f1858882de0c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "77b1d06e83fd51b83b13372d5ef2eb43c5a66f193db857cee947ae4e900e4a4a0c66a8074435984b9a0b007a69cc2b4f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "550c4e7a119fd690f750317dc0e20ad7bfc7fa28fa0409fc572bc745d51340a60e9e2ce2af97f458daa561155130bb97"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d1b540ee39c34ab1484be27d2dd56a14aa48f88668905f9ad176932f4b2cd5d6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "879ccb34343ebd4ac4888091d97f393c5f75cbb066cf8cf1b9b3eb03a3442cb17326c60bd0db1403aa66ed1f0a5a0d548c96dbce74ebc5c3d6d93950f24b417f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.yaml/snakeyaml@2.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/src"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ibm/mapper@1.4.5?type=jar",
+      "group" : "com.ibm",
+      "name" : "mapper",
+      "version" : "1.4.5",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7e7cddfee6b23b8db69a3d2dbe841358"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2b81ab562319a286d2c622a22cd0e32f9733437c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e6d4fd1412b614a874b289b7a7d4158684701f1e07c50f712811509e30b327b3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0942f10a778e7eedf665fa46ed8c6972ac7eb3f48daa867e07c29ffc6985c21736d511bf3e4080c6ea59d3afea1bf7f7bce38cd945329f4fcdc79d2e92cc8d6f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a46de6c7a07dff06aa82bbbec72bcc08652fc9f471095e06bb93d66ffa004819b3baccdd57ba3bc2392eec3d684b68e0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "85c8419fb9f0dc4644f060b2bcdcea97b5d704def97c5cc338653a006e90e359c74f949806aa2c1320245c754dab9b0d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ec9ef8d7ce5050603eca34aab0d32c84630bffb312f2d2c19562e9c88ed2993b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "db57996bc1dba6453f1e3399f3c79ff415ffb5d9a92c997594f16a0f810bb75bde47d1ed470c9ecc41d9f4bbe52c8d7fb45b6d8dee28f86b14263b3a6af96c04"
+        }
+      ],
+      "purl" : "pkg:maven/com.ibm/mapper@1.4.5?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ibm/enricher@1.4.5?type=jar",
+      "group" : "com.ibm",
+      "name" : "enricher",
+      "version" : "1.4.5",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "adc5f4b781b5288bb7bc77fa338c656a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c3b448a1a0d28528e0d6de23caecaf61c068676e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "34080465316106d12a98ec589ef5b7a327b72a644f689d1e743eec95081cc7db"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "21cd400cfc3f9420c0858f92fe42c7bc286e83ff5bc0edb604daa7508921dd4e940c4ad892fe80c624da32fc977d2e94be105c11373973dfe9afe24acda6feed"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b1a1215c15c0ca59cdae0f246dc661f81469faa604b52f0435343eb35f7b433e9b915033a8fa82894a494af8b86b187e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "db7759437ae8c22c052cb9a9f4b6d3b0faddd9ef92af1b3add9aae0e2ebbb999b8ac737ba60ced60b12a849762bc5ce0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e99dd5d2f3f91bad878f7fd0cd8b91b32b2a5abe4670b26c124e70ceb52de99b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "778fcd94b0a00487eb87dcc20ccda80852e3516437aaaae81370c51aee5d2f970e43b537f2656a57b8c8cdf96eabbf17f260e0bbf3cb0131d9cf4f24b79845b4"
+        }
+      ],
+      "purl" : "pkg:maven/com.ibm/enricher@1.4.5?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ibm/rules@1.4.5?type=jar",
+      "group" : "com.ibm",
+      "name" : "rules",
+      "version" : "1.4.5",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5002e7aa0c427c8e165274864824d18d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9d4f13f7ceb0f096cda096a402a4975660eaeea5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5f07d4f335846dee87d8c45cbddc32d472621d7f506fcd1b25ccfc92ec253b0f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "32112ca1cbe9cd2d8b727fe37f5eef3db9adaad96beb3fa961de4491c0a5a1474cd7d995d4c42df349b09f39a552ef604f68f0dc9b63be8f78f83a6a3d00543f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ef6553e249523fcacdb593745704fd9509b047d048b4a4283a20c2cf07cd22e6eeaa6d27d43501f4e1a6270d81f5d57e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0db923127ff6377e9c5cf3dd39991f623b0e2ef2075c24b09ab71b782fe080601e74253a3f617c2af964956373e356a7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "315d57465043dcaad2a52233b643b898b52f23acc94704228c4d1c8bb8ce76ec"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0f05532a172b1b7a4155ae4b56a8a801c19055600dcf49a239a1f155858185fe1aef2e704cffe44f519c897d39c11b6fbe295b67785237202d514df2438c4940"
+        }
+      ],
+      "purl" : "pkg:maven/com.ibm/rules@1.4.5?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ibm/python@1.4.5?type=jar",
+      "group" : "com.ibm",
+      "name" : "python",
+      "version" : "1.4.5",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ad72f1619fffcbdb8411e623bfdd655e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bf818adb0e314d32fc6da17fdadac7948186f7cf"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "425bb9dfa4adb18797e457387e156b5699190dd4eed75e283f5d9b4c46f86d09"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c8d0e866f58d07a005e712466dc2f949b29e316ef7c5af60962232a3392b9f638896ffd9d771f8126103440e5fe3287eb428c3db7ccd4115212319db54980ba9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "68d480ea534243b353673035ab73542260fd362aabc498fc73743f60704ea774a06331823197cefbce0314d8a4a0b765"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "123a364047de07d2ff28f295509133eb4ba125c4b05ef7c432bb1dbe65d094a394fb2c68e108d0c95175aed1d8ace18e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6c41064b3238c53ab01c7a6c793e006b0deec48a824fb7e39bda6222b5e285d0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6403525136ff17aa6cc37c80c1c89a900f62143a75e06deebd8d569e44fda7ab178f6e029636e64764673b69211cd84e94432c2ee8c693089124d8a5ea39ad08"
+        }
+      ],
+      "purl" : "pkg:maven/com.ibm/python@1.4.5?type=jar"
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.17.0",
+      "description" : "Apache Commons Lang, a package of Java utility classes for the classes that are in java.lang's hierarchy, or are considered to be so standard as to justify existence in java.lang. The code is tested using the latest revision of the JDK for supported LTS releases: 8, 11, 17 and 21 currently. See https://github.com/apache/commons-lang/blob/master/.github/workflows/maven.yml Please ensure your build environment is up-to-date and kindly report any build issues.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7730df72b7fdff4a3a32d89a314f826a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b17d2136f0460dcc0d2016ceefca8723bdf4ee70"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6ee731df5c8e5a2976a1ca023b6bb320ea8d3539fbe64c8a1d5cb765127c33b4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "dfd5ff7fe7f852b9caabc81e5a00e20616f98405085f059b64dc2121feb5fa6cb327e11a3d2f954c079811c31f6fd484e90f932d45078796fbfa7dbf1f1eb5aa"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c6ed55a5c2b05332890a43a3ea73b30f42dc23c92ebd054a8b0d29ca8f49fb9361f7325cfa90715be457804b087221b5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bb9e148a87928c3053bcccee361d5d8d81b3c6ea41a390d96c615afd242409f909361c945f3b4238a297e4ebb2ed413b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f28f34565f25dd65fd1a47916e917df9e3ff2c6721897ea57391a238227c96a2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4c8e7a5f10d091bb240e7eb59287d0e4e4420e7a2d2be2b8060111e479540ffae89040377c99ec7f458cd54e1ac0ed0778951cd1f34d5d90571b8a303fbb9baf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-lang/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-parent/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LANG"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-lang.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+      "group" : "com.google.code.gson",
+      "name" : "gson",
+      "version" : "2.12.1",
+      "description" : "Gson JSON library",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6901ee290ab94954f46a32a30062c773"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4e773a317740b83b43cfc3d652962856041697cb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fafc369544e2d4a89f32c353dcbd012410a64a315a3cae9165d4ead6f8960aef5f77ced84c374d6a09af117748adca571b0426eb0e2864f584debb59707ebc03"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "eb24025aba39a08bb673e538824ecaa14c45acdec5fd0f24375f746dfecbf3f328a86d1e4dc47df24394b1059ad9dfb8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e881f0ed39f3cac50753bcae7bff488f19d2a6923d2ad44674a63b95b86c34300fd9126bfebea005d908668ec9e5fb80"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5536a5f2678a6faca03e427e8976550ba933fc60e548ed5fa92f8378013d386e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "227b91fdb9aaa5b36dfd3921a69a5bcb8848cbb16dd478f67aa4098708877d76e4cc458567e9f4079d8161a4c5d5e36c53dfcb2e0e37f86155f3e6ed65ddea2a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/google/gson"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/gson/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/gson/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.errorprone/error_prone_annotations@2.36.0?type=jar",
+      "publisher" : "Google LLC",
+      "group" : "com.google.errorprone",
+      "name" : "error_prone_annotations",
+      "version" : "2.36.0",
+      "description" : "Error Prone is a static analysis tool for Java that catches common programming mistakes at compile-time.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0e48e5ba2cd0a8d8d09bad849b99f6a6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "227d4d4957ccc3dc5761bd897e3a0ee587e750a7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "77440e270b0bc9a249903c5a076c36a722c4886ca4f42675f2903a1c53ed61a5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bd6f5650902526d3db06aa1cc7bd36723658166acfabb823aca27d0b2c3814e83ae24a8217ce915c3e194c2c696a102580b4c21ef5dba61f7610bcb8d580f566"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a5cb9ba6b5bf550de90def11ec4bb014410a14949f8598856e1693e213ec0e7d2b3c6cb41b34ba8cfe209a29801de529"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "00492c18861d7d4fa5517ccf2bcc5c170b575ff9fe88fdc834827d9fc8747846d6345f5270c64dc130228f53ac96f1b6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ec8420b1f4e27c3eef932a764c4cedc8b3547e114285227ceb0612e93648ac29"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "344bc9be8f3417d4bc3e9e073bff4657aace3cac73e5ace038a11f1435d04d3182f344b8237cd6b311ab0748042a4c4f84259713ec2dcbe472c75cde2e787320"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.errorprone/error_prone_annotations@2.36.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://errorprone.info/error_prone_annotations"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/error-prone/error_prone_annotations"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.java",
+      "name" : "sonar-java-plugin",
+      "version" : "8.10.0.38194",
+      "description" : "Code Analyzer for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2955de4fa6de4932f7021f7ca87fb178"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "361fb8d55a314e4d6f36b80224428bd42247ddc4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e3807d69ac59be0524bef6c12ae800c04c7ccbf47c5e5545ad0b6171dd3f7c0f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bade0e3403a614fe10e7615c66691e4def4263c409d2950330c93c97ca27d6f923b3e9ae377ce755a626cf64c7bb43468a4c0a51309417b07c0eabc82ac0c87a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "017c3fd1940de4909d743822b720c73474c9732324ecbc6e38d62b23b1e4859b665ad593e60c0250cf500b6ab0036dfa"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2a3cb2c17d97684c55efd6ed9c1262a02bce585b99d71c88fa14fdd4a4399e591bac562ade8a013a2bd16754677df0f9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4b392a22090315e64e6e1351ae4f017a30bba278c72e83b00eec1d20c9e3b805"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6c1c50856d9fa12d9a9e39c859a4438640dafeff89fea00c1d3fac9a5a0b1f7b330020d33aef73345eeaa92237d08ea0e2b3a87fefccbe3ede25f4aefe943297"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://redirect.sonarsource.com/plugins/java.html"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-java"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "file:./local-deployment"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARJAVA"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-java"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.java/java-surefire@8.10.0.38194?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.java",
+      "name" : "java-surefire",
+      "version" : "8.10.0.38194",
+      "description" : "Code Analyzer for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e2f0789942c9183767821b8b14946ad6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b8dae136c22a10cc2eb11b7c802aa3090b485398"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "828769e859bceef53af5cbe08715a2b1773567ec8061be0106b45d9f370aa742"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "95032d6a4de9d3acfda0dab8581b494b68219eb89a5b0b50d81a60e828f2daabc664eb013fcbcd6f04a97146dadd9b89f6084272fa47e99950081c8a6cff0e97"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3d13d2d9f064caaacba2799b9e5c3b76e53930bda75a4a6528ca19016109e1c14cf942082b4eb51412fdacc7337376e9"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8eed4652880b61ded1bb82fbb99435bab54f4297d09bd31d66db0e876a39b6accf2cea34b0385929cd376871599aebb7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "49246672df3c76d7db0fcbcd2a6c96a200b58881c8267686091a4cdb315882e9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "858f04712bab1a9562cd16c91f407818d6f9df573cac0094b862e84d7a23f2e483dfde0cdac7b27c2f8fa645d508a5b6c3b4cca1083ba206c4d456f46d1d40a4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.java/java-surefire@8.10.0.38194?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://redirect.sonarsource.com/plugins/java.html/java-surefire"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-java"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "file:./local-deployment"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARJAVA"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-java/java-surefire"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.staxmate/staxmate@2.4.1?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.staxmate",
+      "name" : "staxmate",
+      "version" : "2.4.1",
+      "description" : "StaxMate is a light-weight framework that adds convenience to streaming XML-processing without significant additional overhead. It builds on top of a Stax (JSR-173) compliant XML processors such as Woodstox or Sjsxp (default Stax implementation of JDK 1.6) and offers two basic abstractions: Cursors, which build on XMLStreamReaders and Output objects, which build on XMLStreamWriters.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b79898a5756a297a63eb55af14e39a5d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1a61f6c66e732c05ca5d75269ac5d2ea288d22c9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "abfaceda67857ddcbd7e0c85fd54af393290b5b617cee4e4464dee8c24b13d0b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1fb319e63b9537b9eb99dd162d333560c04f4855a58496d8e0826b1a6135cd423d0bc8e10e9a2c6bc946059089d3206af85b6f4618141632b1f1c50f41a49557"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6f1f6f7a27fb10e7ee6847ac18986b3c54b651e79da1fea3d9617ced89b7d575f3e6017d0a8b3500d146b32be0ac0511"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8c12c3b529792653422d8d98a7a56d5ea2b483c835cdf28697f74059699f026883d59a9f29246ff66758b014e66221b1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a80836256d62c04f79a6123c77af82ca926a0bdc3c5b3c619f793af273662a31"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "02a4e7752396dda6b0da136ee4743f7f7ff8211c6aa0a86276474cd17931135dc99f94780856171a4a2c5c0eaa02ca6ae79aedcaf3f35ec7b737e12455d45db4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-4-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.staxmate/staxmate@2.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://staxmate.codehaus.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/StaxMate/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/StaxMate"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.java/java-frontend@8.10.0.38194?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.java",
+      "name" : "java-frontend",
+      "version" : "8.10.0.38194",
+      "description" : "Code Analyzer for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "100f32404fdead08a538dfcc09d0897e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f6ca984ac66ea928cbe6b6d14788a90eff37dc16"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9e31dbca5e8163000b2d44fae820c61a1ecbc3fa024e07930dfeca01e939a067"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "55576d2d4cda16cf98a4a2aa607e4766972b3c0d220a97477badbad303ea2d1d67595b0e01f78c590cfc30f5476cabf55e54a59a339461d8c5648e6e370e3772"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "eb6051fe21139cad6856ddc6ff9223c9ced9105f2e0c1d66db6a6e695b386775469404227c213a1fe6661b32733f13dd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "08ef16154430296b4ae57e179ba79fe2bd645d7c5268484e08515e55f51a4bdc43ad6181051a77d2629d2d789390f34f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a013ac6743a5f9bc4b5f57bdc371025a8a47bb2b26ad6d1562c026873a2e3d31"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b5526f9e2e3036d68af6fcc351689b40131df8c7801162180c8f3f06fbfeb7ac09067ca2c55058eb578a46a36db0e270c6bd4d69fb16ce059082680866239432"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.java/java-frontend@8.10.0.38194?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://redirect.sonarsource.com/plugins/java.html/java-frontend"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-java"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "file:./local-deployment"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARJAVA"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-java/java-frontend"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.java/jdt-package@1.3.0.89?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.java",
+      "name" : "jdt-package",
+      "version" : "1.3.0.89",
+      "description" : "Parent pom of SonarSource public projects",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2a72bdd9f5d2767b98fdc98d55d2e7b3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "76008c8bf12bd13df04b243ac907689377c614ac"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fba226771f23867a972dd068d44b4359f42ea2fecc035955d7a86cc8d3d4d07c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "62701ec3bf1b63f5b3ae0c5e028b9a887ddc49bd4584e1a0278321eeb705180843560eae94bba1693ca89d78dcc5a419fdc2162b13a0237d5c445794a683ada9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "dfa99becfe44a585d6db5187c086223bf63060ab9326625f8982630cc3a2cb553fd6ba63bdc11c0dd0c94b6b5aa363bc"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d76364cbd0cc7d8ca1d39ce7d50aa3a7e7246fc98f7127f01fe76991b5283ebf9238fcecf7332e236f72f50c6a9f447b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "198e072137a715f3f81aa314a1a2c8bde37541d06429264a41802cdc3f2ce90d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "435918064963d1dda8b3bb1a87f1d824f5fd13b1343a098d1d9df7297d948786d308376a57d04f12ac014d865df2b7e99030b92f24bac4de4187bfc5fe5d8bce"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.java/jdt-package@1.3.0.89?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://docs.sonarqube.org/display/PLUG/Plugin+Library/jdt-package"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-java-jdt"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://jira.sonarsource.com"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-java-jdt"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.sslr/sslr-core@1.24.0.633?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.sslr",
+      "name" : "sslr-core",
+      "version" : "1.24.0.633",
+      "description" : "",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1aff676d028ebe3310dfdef58a42cd06"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f2b17ad23d5cd2533c01b9cb3332dae18d9e1521"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d178c71fca3520a686c229a20220910cebd95dd40c6c0b14bb68bca5a96087bc"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fbb6b6987aa0c3464fb71e09d4a89d97c3e2be7306e15ee64b1386732af7f100253ca919aae1f082362d5a92984dc0cbc5f076285f645af42e808171882f47e7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "128ef920ed79a50b68b2fab9548ecf0aa1c86785f7097251b8aa1ccf95a78be592ff2066d4aef35553255d62e047907d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "52ab29e43f7310f16e090d3a03f3dd3ac38bc6e26e7d58f72f4119100b30b0d45e0024d43acb26be7ac87fd47749bb20"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ae85cc20ac91a1d01af9f39b4a51f064ebd4166006b893afe4c5bf37bdec1a90"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "04cfc8a3f872d3a453ea05b8f652e96ac5988fa8735f89ee7ccfbf1abb8e92d9bae91fb445f18598c22a8159b7333d09003490177129539ff87f8b450344b095"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "GNU LGPL 3",
+            "url" : "http://www.gnu.org/licenses/lgpl.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.sslr/sslr-core@1.24.0.633?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.org/SonarSource/sslr"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://api.bintray.com/maven/sonarsource/SonarQube/org.sonarsource.sslr/;publish=1"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://jira.sonarsource.com/browse/SSLR"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sslr/sslr-core"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-regex-parsing@2.14.0.3087?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.analyzer-commons",
+      "name" : "sonar-regex-parsing",
+      "version" : "2.14.0.3087",
+      "description" : "Logic useful to read and analyze regular expressions",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "fe6edf07637491f908f40ee2e4a3032d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bc20010474f0b98ed59e6d8023f034600947fe1a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8498e5b8dd94ead259842d10be699ba9ca3767f984354d6378c5b485fb127cab"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8ee91e322d34ea2642a43b4d5ddc9d73f39accd39cce8bc6439c75aa1155fe57acb392ce53eba7c2677302762bda4b578d8d9c9bb498db9d3dfae4e792fd8e3b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2e61f4cb72e3dfbf4f6f76486f277da55f633b064529d2b66deb85da912323363b98bf0a4489f7e531e478b91bef5b56"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e3b2271074a6689e9a7648215aab01f9759c045271a2ba5e62918dbd9b2e478e19ce384798346c1b3a3da7dcc7121c1e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "03a24bd3baa41fb998b9205e82c2a9b8562dd52b3445795ebb68f9cd3e980da9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f9f9e6701b380d190d50d56d30aa159567c02795aa130f8104b8f3565a5737df480e57330dbee8df742259c87640f7c9ad0d280d2b0998a3c42759dce14966b9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "GNU LGPL 3",
+            "url" : "http://www.gnu.org/licenses/lgpl.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-regex-parsing@2.14.0.3087?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://docs.sonarqube.org/display/PLUG/Plugin+Library/sonar-analyzer-commons-parent/sonar-regex-parsing"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://jira.sonarsource.com"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-analyzer-commons/sonar-regex-parsing"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.java/java-checks@8.10.0.38194?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.java",
+      "name" : "java-checks",
+      "version" : "8.10.0.38194",
+      "description" : "Code Analyzer for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5d39292dcb3aa22d897e652dbdc9c3ca"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0733ef58085b3c80f11873a855f7ad49c0e3b3cb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "12d4587efb2c1c48775b1fbfa49815c5c075841b996a6c9d55c7ba8a4eb32304"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b13b8fc4e945a1ec7c22357a16faeff51046dc0d8849b974a123f38bb52174db5e2d7821795f6ae7b5a9f2618003ebcf27c44f1450f77919ce52b29255f18252"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f6abf96eb1957e776845c04b5c58b1610d63836d937db181bb2d0bfa1a37ba58dfe141167e65d0c28c9c0d6a17dbb568"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0cfcc84c7b3bde917735ceaff12261bbabd9ea8c895dc80812f1df202b3776276ca5a9f8395c1126dd455f6a7c4d2ced"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f30a69fee0a746b34b61ba2660b0b2ede7ced472eab527e7fcf33babfb672666"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4148d2f7624e1ac3baa81087f7a74fdc870eff1a000e6612bfa6571d38b8e61e76f921bb6fdbd1177914df83f52c19a67ba3359ab0bb1aba2c84b514000c9665"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.java/java-checks@8.10.0.38194?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://redirect.sonarsource.com/plugins/java.html/java-checks"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-java"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "file:./local-deployment"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARJAVA"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-java/java-checks"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.java/java-checks-common@8.10.0.38194?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.java",
+      "name" : "java-checks-common",
+      "version" : "8.10.0.38194",
+      "description" : "Code Analyzer for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2ce19613533fe31b58e089eaccd0e364"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "525799a10db464a9d8ec520a98b6eea847b19498"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f3a855e4ee994e859ab85e7fd290177b2bce731c1f7d3e9d5113f8399958eda4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9ccfe321701aca1c3a08a3e5b13ce32cfbc107b5f8393241d0d9e0880d2b545b9ff3bf0d0da1d96c6856fb98936dc8d44965971fe0ab20c35bdbd98d0ad20c60"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9d33b93a01c58dca28c5d395b03fe9802eaf150e6c74271497ebc27ebe2668d42fb8b59d25de9b2668b0408e8a03aea1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ce765cc070a5b9cddf72f528fd2587ea95a519758ac540d60784ba4ced7b8646968385911e3f05e6a485be8e75a943d4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5f01fbe6563a9fbba16d94116759b41a9ba894bacbbf9ab36a7e53c9c261ed56"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "46c540df826f1e977fd8d70cb432890ea6ac43d8960c2a159189f6e2d7d617e1f91904272c6db5dcd746ba5e0e9818a45f201098ad689ddd4e29e5f7b0d38df4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.java/java-checks-common@8.10.0.38194?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://redirect.sonarsource.com/plugins/java.html/java-checks-common"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-java"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "file:./local-deployment"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARJAVA"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-java/java-checks-common"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-recognizers@2.14.0.3087?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.analyzer-commons",
+      "name" : "sonar-analyzer-recognizers",
+      "version" : "2.14.0.3087",
+      "description" : "Shared code recognizers",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "045c63ac24b4162e47fc9a7fe1a83c63"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "db7398dd123a76ffb0ef2939cdb6e4c4b99693c8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e262324d2d1dc29dbda013da139df60cc851eb27695700bd69e78488b1bcd949"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "13b4fa524a1c79dde53ffabc5315fbda6a776fd3247cf31d25c7e82a2a93b79f76bc998d405990192522fba98c1c0deae4b5b8ad5246dca49a4bfbfba14a9535"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e5d91f4094e31414498a73152c896d84b19d62cd7876abb82f2cd927de1fc545c0bd5585334ee9cd98aa804629980bb9"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5c8a1f9c60b51d9b869f53899102075569129174d4cf384dd06c52eadf287ac03f3c47f97cdc8c781688a8e257972f92"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "853a1a5daef4781b94ab0a3549d723d7836a3078735684c5d6707c4857f0d0ea"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cd53b25a638339a2a846a8a2c5f289a65b75bddb9fb46c42ec9d83531ee2107e9408936cb72a12d5f50a60dd738d50af393c509de17ace9f53c0981bb33a962b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "GNU LGPL 3",
+            "url" : "http://www.gnu.org/licenses/lgpl.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-recognizers@2.14.0.3087?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://docs.sonarqube.org/display/PLUG/Plugin+Library/sonar-analyzer-commons-parent/sonar-analyzer-recognizers"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://jira.sonarsource.com"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-analyzer-commons/sonar-analyzer-recognizers"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-expression@6.1.13?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-expression",
+      "version" : "6.1.13",
+      "description" : "Spring Expression Language (SpEL)",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "33a4bfe899830f81b6da0a9c3476a7e0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "be30254712ca0549cbd539ba05c57064917253f3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "42e07bb39674b2b5dd49c27b60681df3cd6a49b63cacacb3620a0e73f4332495"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "408a6ee521962621704c1ba571191442275769b2724c250f1e66c97a131c4b52037f0e3236b95a31c7f4c39ddc2e9390f3b527eba876b2ffc846e662470a157b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b930ff9781c0ed9fb3e7f0a5cd64e13ea135a954d5dddcdc930a943f9be4ed284a45fd7fe9780a25e0da02ab49a9b224"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "696765c466a6add69c2055e5c95d7e95070beb0fdc09bc7ede1aa211b0388de27130afc52577696bbc3ad715e440bb5e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b25933c3d1c8c47bb8af20b067e2630284e70bc38f6dada9e275b7b82ff83e24"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "13f100bd35ca6eec3fe81e41b82cf5db8bc002d8df02e160d8e6c2c090e1d811c6b12e5a72051a1f97daea57f4d9510ba8fe8d7eb6d28ed285742722efd45039"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-expression@6.1.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-core@6.1.13?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-core",
+      "version" : "6.1.13",
+      "description" : "Spring Core",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e1965e1d05b8ed52cee0593007d2e40f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ddbd765408d2665f47017c8f05a7682012f91da3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5f0059701b1c0bcdab78bb72dc252fce9eab16147819587238cacbdbf7b794cf"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9ddc57c8f0015548d4cc7ecb2296a93d7e68510ac8f1d7aa9ce44d92e85bb3650d581924660820ecde30f31de628b021e2f20002cb1bfc465ac4d2b1ac89d814"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a8e04d369edf33d8c7366fbfce1308f977fb92ed68e487d73aaf2e906b92460292abd2034f340b6fd33db7d950a1ff5a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "98cfb96108a108a477212dce815da7dc77a28c008d7a2e3bf5ba272fba92121df92549bb609806ab9cf1509b76209133"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2f460379131649236f8812343600bd336cb1603ca314c13d45600c62b40faeba"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7a0cbb0defb6191caaf6aa9e7a53c7fb075117421b7a1c94df515a14a56039cbed056d177a35dce54bd154755f6260e49723ac3700b9f9f2c5a7abdf0f1fae1a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-core@6.1.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-jcl@6.1.13?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-jcl",
+      "version" : "6.1.13",
+      "description" : "Spring Commons Logging Bridge",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "97ef36acf2ca039e28037b56fe776129"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "37291ff008a66a9dbf2c98e11bd468cfadaa7ebc"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5beec23ef64d0fa1b6ce06d444357f1a6829fd923be5cfabf3215d724f766239"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5e315c3bd176849652f0419117bcce29b321a8710e83177151609cb1908de477a6d3a8d36494831a9538435a859f3dfe6cf70b5ee57662b75e228d039fcbe6ea"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e12150144bc81e246f5f9d56e4fbf440c7cc45c18065f5f133beca7609580784d6b1fb3852b1b5ef33531c9e3966a204"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "240df703aeeba6b21c22f7810dc20d0fdea2bdfa6dec7766c6b450d0150a99c8d101020c1dcf3643d5f2a665393df009"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "63d8736d1e9cd6d81d923b8aa682c770bb55c416af90c7ad049e21442fc1a3f7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "891f8121c6ca90d6e2636a274e67d39bae9a252200b699f999f04d042b41adfc6dd02649cd93682963bbd902d6a9e00ac253efd0ba5199765792ac16ec7f4fcf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-jcl@6.1.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.java/java-checks-aws@8.10.0.38194?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.java",
+      "name" : "java-checks-aws",
+      "version" : "8.10.0.38194",
+      "description" : "Code Analyzer for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6709c7266d72c444d4b2078425a99d60"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a6cbde2fceb11c4f69cf4a2d0aaedf88af24f65e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ba6e9ddb73dfde90749e99b51ddf73c4be18d48237557c11a47db750114ec9cf"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "33e1040a2153971efb298810b426234e5daa6e14718f5e06cb5efad156296d5fff03112a1c91a62d9d34ab25ddf12164f93b7e6a476d1b1d3123aeb21dff8c7a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "210a6d6d38c2a0b0c2952139b4c913ea4293a25972cb6356d204637e56d3687fc3248dc6956866fd3193235dabe39b22"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c15cc0bd31c6a2b71421798607fc6699700233f46d97407796df2f39721ec8f3af4bab55150443e1e9228cbaf6d0dc0f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0c428596aeda4dd9d8966753a24c29355065451d362fabcb028489c1f3d89fc0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6cf8f2bbddf917070f977e06a122e51336e05e8aeea12149167c85e49cc5738d1eb33612bd132bb944246ad827abb6ad7e7af338ba7cd1a7da08551141f95f57"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.java/java-checks-aws@8.10.0.38194?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://redirect.sonarsource.com/plugins/java.html/java-checks-aws"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-java"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "file:./local-deployment"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARJAVA"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-java/java-checks-aws"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.java/check-list@8.10.0.38194?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.java",
+      "name" : "check-list",
+      "version" : "8.10.0.38194",
+      "description" : "Code Analyzer for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cf9c6a4af0510d10745855d15ddc4671"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1ebf8d6fa59c87de3e3427138b7ca5018d61394b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ff7a113637c1dd33dec921a44675abbc97341cf894285fb63fb28329af107710"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "dddc452218b2523f87e4e07b72848b80ecc3d9f0b4dfaf0c671b5c0b638e19323106c0e91f8122a15a72f45119cb4166f5e070d8c8e128bdbf15bb2ac8cc1fa6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "525c2c599f4738329ba31152ec0a5ecf7f9797fa8eb3fe8a026690521445484bdedb164b6e31c70cc1a13988cf265e9a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f0b715aec461f8aca1e3e64e0efc936fa94d1769de194e1304cc0f9bf43676e9eb5734b21ae2371c397a2f23f44de8b8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0845269219a04fae75e4b3285e4d02343ba5fd45a13c500ccdf689b77fc413e4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "29da425a6a39868dbc8b4c788e1e92cc75c4322cfce3ff7c30c9e97a2deea7e73a081236647cf153e98d3cf77fef08314424e723a97fe8f8b151badc30fb0449"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.java/check-list@8.10.0.38194?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://redirect.sonarsource.com/plugins/java.html/check-list"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-java"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "file:./local-deployment"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARJAVA"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-java/check-list"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.java/external-reports@8.10.0.38194?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.java",
+      "name" : "external-reports",
+      "version" : "8.10.0.38194",
+      "description" : "Code Analyzer for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "37fb9356cd7a7fc03775cc03f7f0da9e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "737f348cca9fda51ac979182e55701ffb3682b0f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f8028a6ec1463580e11c4155f943b6195c681b748fe09b32efbf4fab2e2b350c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e44b2773d08288998b2aec53d87395ec6f34d21543843ff1980dfb2ae4112bd19873559408b396e50ee3e973260a7ea93b3765d1ff9bf2e8003b4326fbd46045"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a04cd8e74fa126ce123cfbf59c1c2b9dd2b1c5be49b52edd5361028260aeb52e8c162840547241b79c5c19216c7baf9f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6d7fb36509596875321d04e65d093c498753a1bc70e30d409dd94b09cdd4d23992e23ed3767b06b708dc1545389a14dc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ff0f28592157eddd97d0439b60da576fb0696cdd41accc12dd8ae91c92da9dad"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b0b949a5b77c00aad42fb557716d8a03c59e0efcd79be128bd9c14bd3d1a32c5921fbb3f0866e644fc5a655492486ab045fb79d1a1e7d9680333ead9e6da0422"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.java/external-reports@8.10.0.38194?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://redirect.sonarsource.com/plugins/java.html/external-reports"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-java"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "file:./local-deployment"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARJAVA"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-java/external-reports"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.java/java-jsp@8.10.0.38194?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.java",
+      "name" : "java-jsp",
+      "version" : "8.10.0.38194",
+      "description" : "Code Analyzer for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d8757f03124798fb2e250d51b67329e9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "65edbc3b13e3ab16ceadd7707b46c630045524d2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "28b6643845bc03cfcaf23ca80bbb7402e97e70eac3a0d9570aab122572d6a37b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8ea239357117490f843d876e60c1d1672e1f9e46d0cbf26427ea9b8c0d14be5835c619a7a1930aca0cd41a8fe38969235c79c81124630c473c7c27229af275ca"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ca3f46bee8fd4b2ed24ee07ce9e4fcd48d3a3f2701d7d2c4aaac7aca146336ee1cafad3aaaa629831b8d926e9deaafc6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "61797e88f5f6b6a9f75bfa50183bf59477eb77979a0ceef7521b21a9a4f8a7f990c4149c84e4615a8d0836d9c8b861d2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5a8eca7b85d3438fd96e26917a306ee92873006c9785f81be880e75cfef16deb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2efaf1a41ae3a41d5bb6c150b113e5de1c78b16af5f8b704b2e1daebae2f0dfde8a4fff1b34c6c63ebf0321f795ca176f03e3065f15678435df192c26dddb763"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.java/java-jsp@8.10.0.38194?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://redirect.sonarsource.com/plugins/java.html/java-jsp"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-java"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "file:./local-deployment"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARJAVA"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-java/java-jsp"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-jasper@9.0.96?type=jar",
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-jasper",
+      "version" : "9.0.96",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6a16a87ecd0fc5b46548d32da355d4a2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "31530e4354c86575fa8e183221a4e4b9c772d0a9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "477ef64228f24e538a920142320a17e1bf98facbf58319b7cf4f84c91f41c73b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6e95f7c61a096f0d9ca81ef9d9d66a10dfd24d3b10587228ce4b2d9ed158af53d522282124dc8bff5f02ffcc60b894677135d5ca9ae1c48f24316e338848c936"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "018b0b636121144928363463b710006627c21aa009d6913a04955f7533de5157a50b6b7ac078182e2e239e31e686bd67"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "12010821b227ec35f49c2eeb48c12899de6df02a06438607852df2130a4a90017518bc61d89cf905e83388dad8e30309"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "fefe57572844bdba67889237e139f3944933460430d9332330bf1db60cd07c3a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "89c25dc1ed2dfe52861e39e625111fcb460c0d07655d19c4e26a204446e85efc0fca436e51f1a85ed2923391c26673979ff520820311547ef2c7cab84aa08685"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-jasper@9.0.96?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.96?type=jar",
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-core",
+      "version" : "9.0.96",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "eb7b61992d93a2ac7b2af1276f73a2f0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5cea46a9d71d3ff8d85a0964591c09dbcf014f82"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4f80b8faea09e09b9c471cb0a91a9467f1d84507dcf06d720cdae16c7ddb136a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "09a9c55972640b85f12fd128a6d5f75e99bd18522abd067f86a371cd6c3f69241e30d3a7aef8600eb776fa6ef8e42fba22c6c27f2b83f46f901492b432ebc034"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6754cbe118ce29275a4bba82c2f7947304cc32a416ea129a4057e0bd1f9a2e9d1deee411011dbcb1df33f73b500b32cf"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b2d37ab30d337c7ed92f3538c428c8706ddaf1e94318d837e5018e04947ab170361b0c813ff8ee859948b47db4e00469"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8168264f5009a4f0c33cb2ec424a87fec7a4534a3710b48905f69d34762a3880"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "071949a6eb63a5c94843587c386eb1febdf5074de5a26475a9ed319379a2dc7e191d254186597bcc6c54672396bbe68e82c75f42abc2136bee4c732b2c872512"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.96?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-annotations-api@9.0.96?type=jar",
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-annotations-api",
+      "version" : "9.0.96",
+      "description" : "Annotations Package",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "92ec090a953c381f361c1e124412829c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "acbf9e2e7580a723aca3185bd554d3bc602d1c96"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b951e5c2128fc2782043e73632ea3e1b8c3aad96458f5750b6f586b3079ba7ed"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9081663e411ca5ade213c6b988051e9600bcea5c2ab16cfcbff24e102a86b751937e9afd0ae2d9e7bf56745cc4879c9fdb22d16a44dbc2847109208dc28b49dc"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "70f83dd18d75d5373654e17c339dbf66bca82c04129b7d9719477dc18e5b55edccc92a50eea0a78ae94f3a75b9ed5249"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "031d7711b466563839b2c09307e7ff2d12810f189c1b761d353d0ae5ce30f5de34993fed549ed53c497a514d533464ac"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3bd611928c50b82dac9aa929dfb3ccdec11ca28d7f7d47f02828be8230ce673c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d454d775fb6329baeddf419732bbdc6aa750a6035c9638922ce3c53806369219d906e54c904e19fee94a7aca085d5b9bbfb88fbf4499d40b0c05dd481d795b1d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-annotations-api@9.0.96?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.96?type=jar",
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-el",
+      "version" : "9.0.96",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a0a8ed420e598f2d6ceaefff3ffcd0bb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c60b1011ecbe407823f935f2e5c67e92dab28558"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f006d7f476066df769ff4ba5c5f3b98a67305c9e8f47bb1dc2b0d2146a2ef0ce"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "27a888c5a5edfde7e43337ecf3b1a44d1da23c7c5e535bccf24f8e1313ffceeb6c78a758fe7e533f4bb8ab25bfbb07779c60b1747cce74decfcbdb9b17c740ff"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a4dc073f76665b714e4f38f00d285e29120ea0bc912292f84711d73c139f146e9dcd78e5453bf740a4f5a71bffb7d3dc"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "189b6a7ecda6f52902182d799813d6a60714a80130e2e37d82f25243efe146c7c1e661f952fc6750ac7aa8ca0ac223cf"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cb27ff9c167e788ba1957b8346033aa3ba47d39f64a880f5b35f9e9aad674a30"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "287f5d1869867bb0f26998d51cfe976a526997da0fb50a1895a5a240175f67a378ed71e5df3f58c2dbe8db4c7af5ca5b4a87dc69442989f280c2428e6a9d7f37"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.96?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-commons@2.14.0.3087?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.analyzer-commons",
+      "name" : "sonar-analyzer-commons",
+      "version" : "2.14.0.3087",
+      "description" : "Logic useful for a language plugin",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c1814dd2feee20e13e138f99791c1f1d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "fd24e6961c4e151d3c41553d4bd21e3253bf685e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e8c5f53fcf6fd8cee4662f8008e4cfefbaa51d863249830dd8de4d649764516a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1bc13f7ff9865695117857f7c1492d59de75c795227cbf2dd31dd99fee38af0d108fae0738bb86aca8dc519c006736f03dce203c80705f4149b969f5b52c0e6b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "dce166ba261743e5337a5fbe3c7c509e3531621bb13933cb56c0492425e6da1865700b8f9e28eca91e68e5ac4f414d64"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "84ef011f922b904c6eb4fa19bfd384a1e84a0b24e9e14aa67edec1320387b9def0a29424397b5cd62e0d5c6e9570b70e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5290643e756e4490511200673f0d1612ab6498b497197774f9a9297842c8f880"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2cbb533bc9a9ca43215373a4343fac230136c6f4fed1170fcc67e8d289b6efa15ae601a0f855571b4c81afdea1d1e7c1798c6b9458d5bb310d4a03359cbdd4f9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "GNU LGPL 3",
+            "url" : "http://www.gnu.org/licenses/lgpl.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-commons@2.14.0.3087?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://docs.sonarqube.org/display/PLUG/Plugin+Library/sonar-analyzer-commons-parent/sonar-analyzer-commons"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://jira.sonarsource.com"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-analyzer-commons/sonar-analyzer-commons"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-xml-parsing@2.14.0.3087?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.analyzer-commons",
+      "name" : "sonar-xml-parsing",
+      "version" : "2.14.0.3087",
+      "description" : "Logic useful to read and analyze XML files",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "fb7e8c6f325e7e3329b869621d352bb6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5ad7f1be7fd79c3328f98b6fccb850e620ca2d41"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ecb26a3ceaef1f3766ab95e72a6a2cae7c4a44052ddbc55f5d09aab2be01c54d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a9b1dda58e6c4a6ad6b065017fc83a4c75223405ae2adb35529c515013c8437fdff9690b6d904718e44bf36abda7655c0b2ba5876d918a2dbb23164e1e77d299"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7944c84d2d8d8c67f0cdd65b523155ef66de0aa3958cb0051fa23856743b05599e3009f524c4d26fbe941621b1f50001"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "06af7c9959968fcd6d4b8b5e390ad81bcf074f023cd1e231273a8d5cb6eb0daf60ddb118a7a4a277d34efba0e7c0d9e4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "335ba8ce645335882c95affbc5e618b1f47472becad516884bf465e6b6b01568"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d2d9a57820e856c3b909b509dd479db086f6595ff449da691b8fbad3b9e7794a5f6f593328d2654bcb28813629717c4248f63a5cadf89c7ad34a571ba7d640d1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "GNU LGPL 3",
+            "url" : "http://www.gnu.org/licenses/lgpl.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-xml-parsing@2.14.0.3087?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://docs.sonarqube.org/display/PLUG/Plugin+Library/sonar-analyzer-commons-parent/sonar-xml-parsing"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://jira.sonarsource.com"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-analyzer-commons/sonar-xml-parsing"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/xerces/xercesImpl@2.12.2?type=jar",
+      "group" : "xerces",
+      "name" : "xercesImpl",
+      "version" : "2.12.2",
+      "description" : "Xerces2 provides high performance, fully compliant XML parsers in the Apache Xerces family. This new version of Xerces continues to build upon the Xerces Native Interface (XNI), a complete framework for building parser components and configurations that is extremely modular and easy to program. The Apache Xerces2 parser is the reference implementation of XNI but other parser components, configurations, and parsers can be written using the Xerces Native Interface. For complete design and implementation documents, refer to the XNI Manual. Xerces2 provides fully conforming XML Schema 1.0 and 1.1 processors. An experimental implementation of the \"XML Schema Definition Language (XSD): Component Designators (SCD) Candidate Recommendation (January 2010)\" is also provided for evaluation. For more information, refer to the XML Schema page. Xerces2 also provides a complete implementation of the Document Object Model Level 3 Core and Load/Save W3C Recommendations and provides a complete implementation of the XML Inclusions (XInclude) W3C Recommendation. It also provides support for OASIS XML Catalogs v1.1. Xerces2 is able to parse documents written according to the XML 1.1 Recommendation, except that it does not yet provide an option to enable normalization checking as described in section 2.13 of this specification. It also handles namespaces according to the XML Namespaces 1.1 Recommendation, and will correctly serialize XML 1.1 documents if the DOM level 3 load/save APIs are in use.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "40e4f2d5aacfbf51a9a1572d77a0e5e9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f051f988aa2c9b4d25d05f95742ab0cc3ed789e2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6fc991829af1708d15aea50c66f0beadcd2cfeb6968e0b2f55c1b0909883fe16"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bfd21f2350bf0bb546a68d3303f28c6a15cee1e630138c169344c3f65fe39a15e61c6ff4e5239f38f2f1f9e488eff4d5565a4a0774263064ab6a30aa9fcaaed3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0a35ae0744f05973997b0710cc8d1d774867bc1c1b63ef5bf5f554d1b4c4ab42033f7819430e05ac623e7c8630aa7c52"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b016ed02d907b21c90b4a2560aa4c778e8aad1b5ecb0ba62777f668166c6e7b8a0c0deef7d1e63b7a9b1092c64c8a4a6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "875856aafff433840ee9933c01018cd18c0a13b46bd4472853698ef1dff83168"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1587332fb01515a72b7856b1f566070dcd26fef33c5070039c28684215466a9b9d3a4625cf7181443e3c3a67a313a938cf0775f39b96daf43f5edd4772143c23"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/xerces/xercesImpl@2.12.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://xerces.apache.org/xerces2-j/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://svn.apache.org/repos/asf/xerces/java/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/xml-apis/xml-apis@1.4.01?type=jar",
+      "group" : "xml-apis",
+      "name" : "xml-apis",
+      "version" : "1.4.01",
+      "description" : "xml-commons provides an Apache-hosted set of DOM, SAX, and JAXP interfaces for use in other xml-based projects. Our hope is that we can standardize on both a common version and packaging scheme for these critical XML standards interfaces to make the lives of both our developers and users easier. The External Components portion of xml-commons contains interfaces that are defined by external standards organizations. For DOM, that's the W3C; for SAX it's David Megginson and sax.sourceforge.net; for JAXP it's Sun.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7eaad6fea5925cca6c36ee8b3e02ac9d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3789d9fada2d3d458c4ba2de349d48780f381ee3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a840968176645684bb01aed376e067ab39614885f9eee44abe35a5f20ebe7fad"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8db0283b6840cd6407957d296b802e3edf90653e2722f8e29f86c1c0b60996c4b43e9e065e6864dab89b2138ddb0174d9b4fdda4a93f94eeb884783db82f3268"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "bce0ec0f0f692213a1110197c4a11c333673ae0630481255d12b441a8cba70aecfaf104c3d8d9b500ed2a0a19a2bfcce"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c1d8154ef6eee57dfe6ae9a1c1a2525e9ec2aab3631911a53c064ea6480c0b3b1ce8dd079db7b3693d7ef81daba28ace"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "09eb76497eac5012ce1000c52f4e597c4941a44b9d960b1ac58a19beb2dd63fc"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1e4eb902e50b3388da4d161ee49f4d47b61dddd2ad10e6ef6cbb67c4ebc9043e0b65ae59a4a0c8eb03dd28814ce4aedd7e0d4962a0aedc3bdcf7de37cde38f66"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "SAX-PD",
+            "url" : "http://www.saxproject.org/copying.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "The W3C License",
+            "url" : "http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/java-binding.zip"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/xml-apis/xml-apis@1.4.01?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://xml.apache.org/commons/components/external/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/bugzilla/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/xml-commons-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://svn.apache.org/viewvc/xml/commons/tags/xml-commons-external-1_4_01/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.woodstox/woodstox-core@6.4.0?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.woodstox",
+      "name" : "woodstox-core",
+      "version" : "6.4.0",
+      "description" : "Woodstox is a high-performance XML processor that implements Stax (JSR-173), SAX2 and Stax2 APIs",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "afcba1114fca8199ef26346dd6011e90"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c47579857bbf12c85499f431d4ecf27d77976b7c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d6eb9f2f40049a7a808baf11ffba0737648e62ff52fde9271d808e5d57a27279"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7da4cd51f7082e59b3cb78988cda78bf162e2b02457caf17242cb9cea9b8002ada15d4dfe774ca0355acdea95c88b67c4d06a27a61653cb84c9a46d27b2726c6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6e25d32eb4c127f7129ccd912ff882625d3fa43e8eba9bc55013a27a61806d1b865ec809bd21d58d3dbfa3d9e2a3d516"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d384bf82404b7642340eb1a3f88e2d1e366bf3282534943f98c5f4946656f7e6ea86ba6c7bfeed7c4fda1678afdd282e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7d1e5fbd3f4197fcf6f4d097bc742a0b3f02fe9ae36ef4385362afab6cc85bee"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6020db3580dac2d5c0b7656a062b982d234952fc3feac5dfbb12f91bc019b6af430123ad46e5b5de28d7cb9562aec582febdbbfae8ce35ebc2ce0b837a335af6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.woodstox/woodstox-core@6.4.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/woodstox"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/woodstox/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/woodstox"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-performance-measure@2.14.0.3087?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.analyzer-commons",
+      "name" : "sonar-performance-measure",
+      "version" : "2.14.0.3087",
+      "description" : "Logic to capture a hierarchy of performance measures, save it into a file, and merge files",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "260ff11d5e9322960621fcc19771235b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d2d2da4f43e31d8eb4a7833d5bef77443a092bd6"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "98631eaba3d9c93e037f47e2c6655ae2237a5113be7860a5a514e7dce3dd2d63"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e75267218862e3dfbdecafde531009690eaca91e67d01ea884eefbce61493b5afde9d5f31b78583df88a172520043e7902c7f43e4740546f6948800f5bd66879"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f530115fc93a848d497fd7dc7750e4874d065f0f114e50652002926e8540cae79abf7613921d8ce34559ee89a05fff2a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5f8cc3c4a5c32d5bb462ae396e6238fd034741b55fc083ad70fee4718987032e94b9e1dab13337976ec8b8781289cc2d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ad6c34d787ed84e29ddb44b272fd68dbe8844e01e27efe3926193646ce6e3195"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "342a77c943e44b294a00fca16291a2d15cb3cf06527d60da73a90cdbf328b7e951e7d77383793009ce6e85473a9a4a15986925eea50f6d9b87392b445e58dd34"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "GNU LGPL 3",
+            "url" : "http://www.gnu.org/licenses/lgpl.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-performance-measure@2.14.0.3087?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://docs.sonarqube.org/display/PLUG/Plugin+Library/sonar-analyzer-commons-parent/sonar-performance-measure"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://jira.sonarsource.com"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-analyzer-commons/sonar-performance-measure"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.python",
+      "name" : "sonar-python-plugin",
+      "version" : "4.26.0.19456",
+      "description" : "Code Analyzer for Python",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e899f96a0059ddf807c6380fe11325d9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "384abf428701635d36952b795682688e1dfbf9db"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6678da19876a967674083a66b2ed8815c4d9e5f687c0fefdede15da4b73caad9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cae4bc3b38162b72c4d9aacda465582f561472b11514bd864bdc9f40b4ebab7b2017a9640aa38c3e5ee1dadcc33e4715ddb19f8342016cde3d75984d49449212"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "57933a38abed98bb23d625c0439c48d774fc6cc5f6ca9dbc982c959a4621c5a1d00a8eb3eb640563d3baedea05353084"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c48c896041eba2a775c56a68d16af4831d355ba9e0dccc011fa3e6e95c0b4a6b7d7c69d621d939754d2decf94417c23f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "612faef2a3e3db66efc48e18345ee6caa65dad74e2667bf98e40592d7d2f3314"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a32a1244ef9c8c6d4e5e84fda1de2600742838955863018f562524eedef9165b54d115cde925ba58f9f98c20fbab89c13d4bcf811f5229f21e37c8a65762eeeb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://redirect.sonarsource.com/plugins/python.html"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-python"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARPY"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarCommunity/sonar-python"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.python/python-frontend@4.26.0.19456?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.python",
+      "name" : "python-frontend",
+      "version" : "4.26.0.19456",
+      "description" : "Parent pom of SonarSource public projects",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "94ad1cc9df94cb04f019ca049be6d444"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "862fa16e2b5d72db478743b3dd08b3a17f1e162f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "619155227119e3df62c55787abd289004a375acc054b5a3735c931338f6f2ec7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6a59deb7bcddca6b5cf5617b1721e84839dce86701c52fe820fc7e83fb5d588acbac1587aca3e6eed8799c80d4f30db77f58f6f350023cd7bc26a40b30cb3f13"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7f891ea0e672816c4abcc22aae5ab5e851daf23db908aeab31bc1b6e7222418e0710e5e8b9f1f9d2a1c695d2be51b68b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "63ca2b6d3eb486470151e3b0879d3885cab4ca0ecd5ad72f78300cd7889053cc03794b1d0ed4bd8c71094c810fa295e4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "df2730847aed831bc3f1be737ec673eb573e87eb24299eb6eef155b242ad6d44"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b052bd6826fc432122a036123dced01c03595b975014ed49c06145929622accd0ef9f7d0451a05a78360e63130fcdc8bf0ad32e1f31d52ad2cbeb0c40f92941a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.python/python-frontend@4.26.0.19456?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://docs.sonarqube.org/display/PLUG/Plugin+Library/python/python-frontend"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-python"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARPY"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-python/python-frontend"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.protobuf/protobuf-java@4.29.0?type=jar",
+      "group" : "com.google.protobuf",
+      "name" : "protobuf-java",
+      "version" : "4.29.0",
+      "description" : "Core Protocol Buffers library. Protocol Buffers are a way of encoding structured data in an efficient yet extensible format.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5de9c1cc9a647278ab03d76ccfb8ff9d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ffea90ab158435d68de76951857ef5f8b0f98365"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "16901851ebe5e89fe88aaad3c26866373695bc2e30627bb8932847e2f5fc2e76"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ed9aae4faa56c04dc086af07078db3734f675eb4188bb2be98c94cc59a8e4e77b74195c47d70c7b697bc3b938e106fdc137ffda5358b3029795f28e7d9216d68"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d204ff730ba5eff0eddd9439f05ab89e87194fc6c69d50054da593ab7537495207374840701867856ea1e9aa87ef1e14"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9a3dc4e7ef4e1488b6ee4a653d9f47569bb3f543012ec20fe695d1bba2a7da8e329ffe70d5ef8e43fd9da1721fe3f3c1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "16fec3a2d08bcc363c69d2a260a78020636d94dd4ed929050d8e8b51d37960f0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "37c5a864aa97fd50a88a5c9b2a9c7eedd646eb4655ec041502e1892efb55b2f22e9f2292dcca120e74755a11f92dc41616e1dc6919d8906fe2c5802e25ed1187"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause",
+            "url" : "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.protobuf/protobuf-java@4.29.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://developers.google.com/protocol-buffers/protobuf-java/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/protocolbuffers/protobuf/protobuf-java"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-databind",
+      "version" : "2.18.2",
+      "description" : "General data-binding functionality for Jackson: works on core streaming API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1b56887bcd3eaea1ff710eb673e610b0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "deef8697b92141fb6caf7aa86966cff4eec9b04f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4b364e6850dc89172fcf1d4dd26b8ff5488eda44ff4657e22dd265203dd5ab3c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bbdfaaffaaab2a032a754cd9dade06552e9f79fd39ae396873315415219b37e0675fde0a02953efe0701e17be4c282b118a96fcb752f53ca37ab89624f0a52ac"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "77607f963531b8b7a963e0691ec0196d0877f13763fcd7485fbbe14a37054a9babd343aecc96c8d29ec2480546cd1e4d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e02fdf4bba51730989da3efac6e0dfce5649215ec78c7d21713386d36874d621f65ea9881399ef80c87a9436877453a1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ced61fd9988c4418e98f5bd061a3aa099dd4e0a0074a272e87803262c2177bf8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6f6610e9bbbfd344ebd716a7709a19bdcf0180f214437473602db312a5e6d6e592bed40776ce9a445ab6b7b5c0fd9291fd11257a6b06e5dbf4b971fe996b2972"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-databind/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/jackson-databind"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-annotations",
+      "version" : "2.18.2",
+      "description" : "Core annotations used for value types, used by Jackson data binding package.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "79d38d3c51068a2bbc40268d02f80763"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "985d77751ebc7fce5db115a986bc9aa82f973f4a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "581bd61000ef7648943f781ca05689e56d03f6052748365a8e2b3a9b5d3fa32f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d375e5761052e202e409400637cdc9ce0f45cf01a90628f36ca3c81757ac30695cc6e60146cbf14685c5c50912ad932564eb794ea76ab8461ce1786a02eab867"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cc68a2e188dfb8a3687542b7e6b0d2b8323536dd82716a545f73320915e5f9602cc7a3c3d67a15f5adb579c31d5ed96f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ffcc40615a2d6f0c0382595da8601f7501dfb78f6f78718e9f05f309253379e9d9101d82bc7aaf8735746eafa190d8c9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9cb3a706d1bc0401a7bdd9c42a6ec048cd7bebce9f60f395e44c254a67ea230b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f1a5af82d49e1db5898b4caa487a4ae061cf31b5db25e2172fdba59970dab3308618f7e34f6fcf0842b7c9da958c274d69022d10d85f3e862be88a44ef8b7fc6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-annotations/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/jackson-annotations"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-core",
+      "version" : "2.18.2",
+      "description" : "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bf935e6eca3a57defa13918661905cb0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "fb64ccac5c27dca8819418eb4e443a9f496d9ee7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d8054ae7c0d1c2d2f55d28e46026ebe5892881f3fab5f439233184381c3b4a1f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2223f6d8235c6831b488dd2723a4569e4dab6c2371f0e39f867b57a3a443e093d1fce05dc070a350fa306d7e952888cb09c7c816254147b01083d122964fc3a5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7c5183b4e0ceb3d9dd089e29253832fdbe5f126a7b8c08fa66ab46f5050eb3b8fd792e00bd914f49000719e547586e23"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2a973e2dcd1b65eb63f783878c542fa804254c880d47180717cd5ab239670b529c61ca4de647d4683cf4b459b6a7f5df"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c99bd2cc1f13748357bf002d92d83f9f2d14d777c5e3fb7ed38c6891c76dbcb8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "10b0328f2cd2a347f8c3eb8ed1967036b8940fe9b444ac27ffdb66bd373686a13fe7ec7498de5b81af1a301ed4afeb85aece0afb782aa6cadcf78362fa7ea5ae"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-core"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-core/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/jackson-core"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.python/python-checks@4.26.0.19456?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.python",
+      "name" : "python-checks",
+      "version" : "4.26.0.19456",
+      "description" : "Parent pom of SonarSource public projects",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3f7a033a06091b7c050e86def9492e78"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "931b0d31829cd1ab0d50adde75bf1014fc6e49ac"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7858d94e174f55846a7c3de644e1b292803fd6e06bba3bb2b5d6c6345d823c76"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ca27fbbb6f725d21eca4a2ae2a0923634c0b6ef37a91c8b3bfbcd75bf77bc71f6a8fab55886d6d3209029f6f1e1b50f32afed4577389f1fc92acd1595c6ee633"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "38070cfa64c9bd33da919f2980a25f1ab49511f226e2b015899828f7249d43b4896ee23505a6a63ab371cfe3e7c09602"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0f523a710ca21d703deccf6e2f3b648e4c7ec3828603f867bf01017364bebadaf4eab1a94833eb4b64af016645a5f7db"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d837c47e2cb666d5f7dedee68926991cfe39031c8fba0a129becd380def15ef2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2bcd8aba70e70d2363af1952444e557287f1a59256dcea3ffb64a46d3d929bb981a8a2fbcf426b8dc1cbbbec28814168c8d06dc5bb7bd15c5802db3b214895fb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "SSALv1",
+            "url" : "https://sonarsource.com/license/ssal/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.python/python-checks@4.26.0.19456?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://docs.sonarqube.org/display/PLUG/Plugin+Library/python/python-checks"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://cirrus-ci.com/github/SonarSource/sonar-python"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://jira.sonarsource.com/browse/SONARPY"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://community.sonarsource.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-python/python-checks"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-lang/commons-lang@2.6?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-lang",
+      "name" : "commons-lang",
+      "version" : "2.6",
+      "description" : "Commons Lang, a package of Java utility classes for the classes that are in java.lang's hierarchy, or are considered to be so standard as to justify existence in java.lang.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4d5c1693079575b362edf41500630bbd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0ce1edb914c94ebc388f086c6827e8bdeec71ac2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "50f11b09f877c294d56f24463f47d28f929cf5044f648661c0f0cfbae9a2f49c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4a5a3dbe4941c645e2cca068cca5c1882cfe988b02e7cd981d1e51784900767d1deab0e0e0566f559c9fcabb4a180e436d5bb948902d4f4106f37360466afb42"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9725bc421adc1dbcd6f937eca0f3075d186a2b353ece4cef66b0fe81bb8d3f7d7641c43e86d657ef526c719f0c2a8c90"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4bc4eaaf2580ded6d552b96ae5261c936de95f69a1d137c47279c51bf2aa1406ae44f69ccc94486267b8441e53c4bd74"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b68d49ef037d428ea0c3e67a7a20f3d68a134bef30a1639ec08d28886b9f5629"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2e9ffc0608827cffc0b48b7a0f35d371c66586c99fea2910f7c2a237c7c57d9ae4d65de7c8e018362c2e4f963c2f70a9196cebf35457f1dd0cea6c65c256f673"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-lang/commons-lang@2.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://commons.apache.org/lang/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://vmbuild.apache.org/continuum/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/LANG"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.apache.org/viewvc/commons/proper/lang/branches/LANG_2_X"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.codehaus.staxmate/staxmate@2.0.1?type=jar",
+      "publisher" : "Codehaus",
+      "group" : "org.codehaus.staxmate",
+      "name" : "staxmate",
+      "version" : "2.0.1",
+      "description" : "StaxMate is a light-weight framework that adds convenience to streaming XML-processing without significant additional overhead. It builds on top of a Stax (JSR-173) compliant XML processors such as Woodstox or Sjsxp (default Stax implementation of JDK 1.6) and offers two basic abstractions: Cursors, which build on XMLStreamReaders and Output objects, which build on XMLStreamWriters.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cbc599b621abdb9fd93d0c0527b6e273"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b0b767fbc22683d7bf26a14ae1c5817561e21d00"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "18c8e8b0507afe307be25c825e058fe91514cb3d8616a11b37225bbb760a143e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8d8a336b79c83b8c229aba7cc56738271f7ca0b5387b09c246a18992299d0061015cde1f07da07b0ca6da8ac66eca4846269c48fd090968cf9f4f398d923dcb2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6f61dce2306717d3ba910ef8657977cfcc83d5e6f87b4fca30c96bb52feb416f187227963a5007f73ea120a93f7b4684"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "165746fc80503b39ff6c3ecf7bd9516a30bb961270bb3ed1b2d009654d2c8ae1986261adadf6e7426eb00b283d8580bb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "dc24cc41221fbcb753a407f0713ca0648861c7935e4ba2cf7e95accfb72ef434"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bd029443e45d4a57e9d36587b0155cca05324282c48d259c1eae7e34a999dcff4ccd44590ca6fea208cce07d7034dac87d3155e46d2241c9f09b8de530d60a5b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-4-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.codehaus.staxmate/staxmate@2.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://staxmate.codehaus.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "dav:https://dav.codehaus.org/repository/staxmate"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://jira.codehaus.org/browse/STAXMATE"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/stax/stax-api@1.0.1?type=jar",
+      "group" : "stax",
+      "name" : "stax-api",
+      "version" : "1.0.1",
+      "description" : "StAX API is the standard java XML processing API defined by JSR-173",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7d436a53c64490bee564c576babb36b4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "49c100caf72d658aca8e58bd74a4ba90fa2b0d70"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d1968436fc216c901fb9b82c7e878b50fd1d30091676da95b2edd3a9c0ccf92e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "43c24e8dbffa9b932492c8ccf2b91926b2ba3d1d34b5a9671c689bd24d4c220b996708a9667521641d1abbf29404b653755b6f6f3dc0ad0671f5c09db332ea06"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2e6c232d3012064dc17e10c2e5b281728a6771eb0d74868e730caf60fe6f96fdd6145759fbbf9d1aa2e07eb1f49764d6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "03ebb8db88d04b7308570c1058aadfb6a81d3d6725b1dd13a049ea984ed1df42d3e0f8163e1229752228cada978fb462"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8173e3e3a0db17b3dbb80c017268858ecda57c819e5b58dbe202bd8087664bb1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e9a7c234dfeff5d4cabd034a536f31ad5a141e30b0ad2438cf5856dd6c36eeb16c69b8bc1ba3ee6bba91f69cd3cbd450953249f2f0eee0a9a22d49637b575f4d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/stax/stax-api@1.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://stax.codehaus.org/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://jira.codehaus.org/browse/STAX"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://groups.yahoo.com/group/stax_builders/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.codehaus.woodstox/stax2-api@3.1.4?type=jar",
+      "publisher" : "fasterxml.com",
+      "group" : "org.codehaus.woodstox",
+      "name" : "stax2-api",
+      "version" : "3.1.4",
+      "description" : "tax2 API is an extension to basic Stax 1.0 API that adds significant new functionality, such as full-featured bi-direction validation interface and high-performance Typed Access API.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c08e89de601b0a78f941b2c29db565c3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ac19014b1e6a7c08aad07fe114af792676b685b7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "86d7c0b775a7c9b454cc6ba61d40a8eb3b99cc129f832eb9b977a3755b4b338e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "911e3e250c9ac9098899f12db584b83f36d91e8cca1afeef38c19952a168647dbbc88cb1cbdd5919769342ed09267263a142b12e71cab465b25daeedf2255cb7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "83c42936c43d6d6826edea636cf315924cdf52a7201bf07f1cf87a30d2b2855088306c94f39dea55529fed0360cf563f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "905976003ae70127f2c6142070da5736fc4a01b7a98008fefa1270fc9096691c1307e002f3b6381da462a92f2f31478e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "308d5a1692fd0135e5af967b0b83803a2fd835429ac83401124a0357f99cbb84"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ac3d87dab7f1e89c83f039557557536433c52a0d3201a2f514b82bb8b4f454eb9fc28b02b46a45a9caf983239612cf270085270421e4fd79eccfce0fd01f99da"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-4-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.codehaus.woodstox/stax2-api@3.1.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://wiki.fasterxml.com/WoodstoxStax2"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/stax2-api"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar",
+      "publisher" : "Google Inc.",
+      "group" : "com.google.googlejavaformat",
+      "name" : "google-java-format",
+      "version" : "1.25.2",
+      "description" : "A Java source code formatter that follows Google Java Style.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a6df46f05d2a4e989adfb559d6d9010f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7fe38facc9124b0ab935f3b6d9e115a7dfd23e56"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "938d0321c3aadc8e45a51e4334f61ca9f71137908e0fe8853925ee2125e98c6f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1616d32b814b78e4ca67719d828d10d61c24096194b4bcabfa4ea14464ea05c970ce7cdb85a2d8fce24f9f960d1900bd4ae9442f20e3fb600f9f7ac42084bf26"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f9783ea875ed5d2c0f83bbbbfe9c2110e8cee75a784da664c7971278fffe9af080800d33fc461663069397a9b219397f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "80d9067987312ffac7dff91d521532df27a4e929298b8f1dc4341b757617797a876012df01ee2f6cbfe0b52d2c7b8792"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2a76b681aff12a4ad26ae372bfcdf141f6eeb9cb29c60debda65f88aa2dced1e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b821a5c7d47d5acaf834e53d68d5a016959ddffa2612a57897199a72ebe594f7fe820a5fb429da3e7bc014e89524034ea15a1cadb74977340609df2e2d2c48c2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/google/google-java-format/google-java-format"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://github.com/google/google-java-format/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/google/google-java-format/google-java-format/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.guava/guava@32.1.3-jre?type=jar",
+      "group" : "com.google.guava",
+      "name" : "guava",
+      "version" : "32.1.3-jre",
+      "description" : "Guava is a suite of core and expanded libraries that include utility classes, Google's collections, I/O classes, and much more.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "adc3cf557a48d15cb71be90948558923"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0f306708742ce2bf0fb0901216183bc14073feae"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6d4e2b5a118aab62e6e5e29d185a0224eed82c85c40ac3d33cf04a270c3b3744"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f575321aa79046f2c12bdf9895db7e235cbaaa8e913389ae48ec4bb5f387d6bf066ed98c5f2c7854bf0c56bb38b59b005ca3c16d68e314743491a223a18cee47"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "efd979f8c807eb973c7bb2edcede11c2881db4232147bb94069701fc002b1c336651aa3347858e3ba25cb89f3df69428"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "83429ce32c8a20a7314175c053ba0a0e57c20486e6f8abcf7bf1e19c64148db70ae8e6b4437ec168f53b37a653e8bb24"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "52974020b1d930e646d2fe26b13841275fb9c51e81c28140993c228adda71e78"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b9bd05ca990c5b76c43248493bb29cbbaad5aa667f394714f35765a8ec04c302a19c4f53f610485c933281211cd6bf4a11a14aaf754ffaed33e02c8b1b78289e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.guava/guava@32.1.3-jre?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/google/guava"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/google/guava/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/guava/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/guava/guava"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+      "group" : "com.google.guava",
+      "name" : "failureaccess",
+      "version" : "1.0.1",
+      "description" : "Contains com.google.common.util.concurrent.internal.InternalFutureFailureAccess and InternalFutures. Most users will never need to use this artifact. Its classes is conceptually a part of Guava, but they're in this separate artifact so that Android libraries can use them without pulling in all of Guava (just as they can use ListenableFuture by depending on the listenablefuture artifact).",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "091883993ef5bfa91da01dcc8fc52236"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f8d59b808d6ba617252305b66d5590937da9b2b843d492d06b8d0b1b1f397e39f360d5817707797b979a5bf20bf21987b35333e7a15c44ed7401fea2d2119cae"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "67659dbd9647ec303d7f15128dc9dba19b98fd8d74758ee3b602451e32c855e236ccaafe08edf4bbfa245f981268440f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1460875f0331c5fa3791772a6a322a7db180261bc2adacf7271df1fbf3b088a587a755a604c039982cb593c5cfc1f101"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ea86406e75fcd93eafe3cde1b3135ba485f1bb9b75fed98894a0bf1f0aee04f0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "52ac0f487ab5dd27c9f2e54fd1d84c7a620cae9d49be4072aa2b11501787bf4391ddaa13d02eccdf19e8eea46aecbea5f6064b26777c1b836108a280652e04ac"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/google/guava/failureaccess"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.org/google/guava"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/guava/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/guava/failureaccess"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?type=jar",
+      "group" : "com.google.guava",
+      "name" : "listenablefuture",
+      "version" : "9999.0-empty-to-avoid-conflict-with-guava",
+      "description" : "An empty artifact that Guava depends on to signal that it is providing ListenableFuture -- but is also available in a second \"version\" that contains com.google.common.util.concurrent.ListenableFuture class, without any other Guava classes. The idea is: - If users want only ListenableFuture, they depend on listenablefuture-1.0. - If users want all of Guava, they depend on guava, which, as of Guava 27.0, depends on listenablefuture-9999.0-empty-to-avoid-conflict-with-guava. The 9999.0-... version number is enough for some build systems (notably, Gradle) to select that empty artifact over the \"real\" listenablefuture-1.0 -- avoiding a conflict with the copy of ListenableFuture in guava itself. If users are using an older version of Guava or a build system other than Gradle, they may see class conflicts. If so, they can solve them by manually excluding the listenablefuture artifact or manually forcing their build systems to use 9999.0-....",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d094c22570d65e132c19cea5d352e381"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b421526c5f297295adef1c886e5246c39d4ac629"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c5987a979174cbacae2e78b319f080420cc71bcdbcf7893745731eeb93c23ed13bff8d4599441f373f3a246023d33df03e882de3015ee932a74a774afdd0782f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "caff9b74079f95832ca7f6029346b34b606051cc8c5a4389fac263511d277ada0c55f28b0d43011055b268c6eb7184d5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e939f08df0545847ea0d3e4b04a114b08499ad069ba8ec9461d1779f87a56e0c37273630a0f4c14e78c348d3ac7eb97f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1f0a8b1177773b3a8ace839df5eed63cbf56b24a38714898a6e4ed065c42559f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6b495ecc2a18b17365cb08d124a0da47f04bcdde81927b5245edf3edd8e498c3c3fb92ce6a4127f660bac851bb1d3e4510e5c20d03be47ce99dc296d360db285"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/google/guava/listenablefuture"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.org/google/guava"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/guava/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/guava/listenablefuture"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.checkerframework/checker-qual@3.37.0?type=jar",
+      "group" : "org.checkerframework",
+      "name" : "checker-qual",
+      "version" : "3.37.0",
+      "description" : "checker-qual contains annotations (type qualifiers) that a programmer writes to specify Java code for type-checking by the Checker Framework.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1ff1eed173ff9d6f208d0a5be8f5623d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ba74746d38026581c12166e164bb3c15e90cc4ea"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e4ce1376cc2735e1dde220b62ad0913f51297704daad155a33f386bc5db0d9f7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "98f92a4d14b77f2946de34bc64bc0068505ba8893a734e52f6458e3061fc7471bd5a60c073c938302b7b78d51205929134207abc24f0edadd3db1e1f57755de5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6a586fa9ead4d6edeb5e73a98af109dca2bf95e950c3c4862773f40e2eed5ea80208021f187fe717963027f7ea2bb489"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0baafa897a7a5b9095680b5534841c537518c67a5ae9bf5923aceeb5aa3283551159c614b7fcfc205f2b5f77c144934c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "68056437b32f1a878d9b38ca2d4c6d88e9ca76b6eb705e7a946bc044010b722d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "66ec2f2416d564035e78295e7094ec1c23b76870d0095adbb9ec7e2d00b94684dc3c4ac08640b7ba14465ddc305382e5b20240d5eff31875d2ffe4682088a2f7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.checkerframework/checker-qual@3.37.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://checkerframework.org/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/typetools/checker-framework.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.j2objc/j2objc-annotations@2.8?type=jar",
+      "group" : "com.google.j2objc",
+      "name" : "j2objc-annotations",
+      "version" : "2.8",
+      "description" : "A set of annotations that provide additional information to the J2ObjC translator to modify the result of translation.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c50af69b704dc91050efb98e0dff66d1"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c85270e307e7b822f1086b93689124b89768e273"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f02a95fa1a5e95edb3ed859fd0fb7df709d121a35290eff8b74dce2ab7f4d6ed"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f8263868a792b41707c9e7fe6fa5650a14cd93fbeafad20efe3772a3058fc933eb59782ec59e6eb9b9c569aa96da80134ae9fdf7547b69c44a97087efddceeff"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e6087ec31fec8289158496ad2ed6ce8472d5d513808a312e0782cedac3b86c37a62a63c0b5ea3839491d109fe9e148a1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "10add34bfeb8612283eef89ac96747a3c9b755acd80ad526e1addaeb7efd6323c52b9bfa1a3d34adb40e1ccb963ee65d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b3336f8abd6b1f73b9f06d306974557000a000073bfbae6b54fda26d17dbb072"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d376c184a6df071c4e93b913d175b5c2e63deac37105dc20342c19bdda62e4e9598ca1e8bfb4f4fd5cdee6dd5ac3b8af49e2c5193e324d59a59ce1f7adeab627"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.j2objc/j2objc-annotations@2.8?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/google/j2objc/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/trunk/oss/oss-parent-9/j2objc-annotations"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.api.plugin/sonar-plugin-api@12.0.0.2960?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.api.plugin",
+      "name" : "sonar-plugin-api",
+      "version" : "12.0.0.2960",
+      "description" : "Plugin API for SonarQube, SonarCloud and SonarLint",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bb7324586818a5ae90c73ace68d8099e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "738c167a0c3e59abdb00d836c41e80ecb3e5b2f0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "813a68dd8af7c2c2fa901fdadb3cdc21581fcb74c7649b46bb8fdaa79108da08"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d43d1b62aabf8f87c58193910e2223a19c3f74acfd2e6e9891a552a888dd66755669df19a96ac4956237b8eb6cc8b7372153e1511d8572b3814a9c0a56fc394f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b439a3e58269747439a94404b240a4072cdc9f33bc3c842595e5cfa5f3c1618a9a8dfda9047d7ad14c3861258063c197"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "aecfb4beb7f7e4304570481aecc8361ce58f5817d3d973f5d2ffab707decc235ba712c04f940dc5fef4f2d4422912ca1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "55a880e270134b01d911c124efce4e1689cbc97d46dee6bb066e8139ddb4ff20"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0efc78f3e6bbe93bbdfe07ce7885c5ca72d5bcb771447ab5f1fa066625cfc890584853d0a7e160fbe4302bca2be5f54b28720c6080a615f1f3dcafdad5d53cec"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "GNU LGPL 3",
+            "url" : "https://www.gnu.org/licenses/lgpl-3.0.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.api.plugin/sonar-plugin-api@12.0.0.2960?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.sonarqube.org/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonar-plugin-api"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.sonarsource.sonarqube/sonar-plugin-api-impl@25.6.0.109173?type=jar",
+      "publisher" : "SonarSource",
+      "group" : "org.sonarsource.sonarqube",
+      "name" : "sonar-plugin-api-impl",
+      "version" : "25.6.0.109173",
+      "description" : "Open source platform for continuous inspection of code quality",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4f957d9f6fe53d8c17c26b46fd88be47"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "804ae2d9049f8afd6fb474c3c96bc9267c94f99c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c1e1cc10a972ea1aa011bb39a619a9cfd21b47b3ea497e6bca9ae826fce89420"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3a07a87b1bd5e571b347fb8014184146105f089d8d09ed1cda5659e22e0104265d1e7b9a763587481e4c0ed7cc4557d86487b03920cc69707c00cdcbf4f208f0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ddc4b8021e450b141199478c47e2349ed94d024cca2b3dd5c70441cb5e2a8c96385bb1cf3fc127be2190453882efe680"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "190620a93268c43cb4ee73003a2228b3a7227ac98fc55fc37c2b70e125983f53c3694d0d15b5074c7f72746b1dc89711"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "60b2849034fbf804fc19f92244e4715a214e0f360a88c87de525385c234e2f7f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "91a8003517d7426eecbecb6dbeb1d29f1e38b56c26e4bdde487cce4fc3d78c5360f0348b3ad74f4ca7f15e9599e40d9b518588702aa8644541958ab3eb4fe393"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "GNU LGPL 3",
+            "url" : "http://www.gnu.org/licenses/lgpl.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.sonarsource.sonarqube/sonar-plugin-api-impl@25.6.0.109173?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.sonarsource.com/products/sonarqube"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/SonarSource/sonarqube"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-codec/commons-codec@1.18.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-codec",
+      "name" : "commons-codec",
+      "version" : "1.18.0",
+      "description" : "The Apache Commons Codec component contains encoders and decoders for formats such as Base16, Base32, Base64, digest, and Hexadecimal. In addition to these widely used encoders and decoders, the codec package also maintains a collection of phonetic encoding utilities.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2abf189633424b9292fd57a3192c0ed5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ee45d1cf6ec2cc2b809ff04b4dc7aec858e0df8f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ba005f304cef92a3dede24a38ad5ac9b8afccf0d8f75839d6c1338634cf7f6e4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4d974c2203dd6780da6e50ec1c7d8ff727f9ed55fba706fdc50b9484fc5da5e03b67bc6ad2f0d9ae74f823ecce04a40c513bbabd8bf9e91ac8fec04cd3519ffa"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "75d428b434c25041068005fd48f720ddfec8a9fc044b8df53a668828894e9ad542b92601a224d618200e3953ee3c8966"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b0d03e9b6b548ec3b7e3c0ddc644cf40d36203606fd69be3fccc72c86b0e048bb6c8e7bd74afb77e371e839bce7cc6aa"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c33f900364c7ba15976e262ac26dbe4ece516bed72278da0e6c636d2c7ffabe6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fefe6c1c33f63b9a873a522f8b1f605e4197ed9fe849af650ad8791503cb58cf3d4facafe4f46e070ea11ccfbaec1084e11294154531a07d8ec18ea9c40d9769"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-codec/commons-codec@1.18.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-codec/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-parent/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/CODEC"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/commons-codec"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-io",
+      "name" : "commons-io",
+      "version" : "2.18.0",
+      "description" : "The Apache Commons IO library contains utility classes, stream implementations, file filters, file comparators, endian transformation classes, and much more.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8cce74ccf461cd6502ae04c908eca917"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "44084ef756763795b31c578403dd028ff4a22950"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f3ca0f8d63c40e23a56d54101c60d5edee136b42d84bfb85bc7963093109cf8b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "786778529435d8a14ab6ce2176cdf2b9ee6585a71893b785f26257122166dcefc7c4af3f612eda3974b06c16d06fc357178bf28b9b74010e9bc04c33221adc2f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4be7ad9b352412ddad3eb00f2e44f1236216d3e713546d34d71f3aa8e589b06636abf22dad0c28e11a0cd7b54ea0496a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d003d33c2cd37806d9d8f0576b65fd51fc1f02bfed7716279474556ef98abfaaddb5b5622762b64458bec6b57f77ceca"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "89019fd824ce65aa33554a848dce2ca47f09c3a261fd22c699342d99579e91d9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6edaba8f76bd3e96421ae3611fb32414b064c5ef2fdefd7402f3052c5849e06aa6dfdd218a6df97b25cdd7997df0c9d643af960c4294f2e89dffb052b4b9d8cd"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-io/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-parent/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/IO"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-io.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-csv@1.14.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-csv",
+      "version" : "1.14.0",
+      "description" : "The Apache Commons CSV library provides a simple interface for reading and writing CSV files of various types.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a99fea24d864189c1aee1575f43f2e22"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c7cc057084126ea93617b2b809abf82432d8f9f5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2f34d69f89dc94d606e250d5eb26205923e5dbc2c3891d3575f86c849f7f8726"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a8f3e364fe76155f8a6a201bedec52d8e09b712752c37fd3380f71da397dd78aae01718060b8ce96f8e0ab692d33b29c04a4cb6ee3b0a374d17c3f6456abb3ab"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5ff36928bdb5b680efbdb781ba193e0a5b46316fc711aaa3cd54f3ab0cd1319cc16c39f362c398c0af546d33aaf50143"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "48ee648d11b34d83ae39d1f71a68ab252b73be822276a0d5a34f2b0f7102fc8fb6b56c7df9f60b65a307c43cbb640eb2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "69739b61cc7a685503e02147d5a0e88ae3a09182e3d4fce7c6a81f058f006c3f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5ffb4b19e48e26af9ab361467304f4ed119ae0375fc637613d1f6c562357201f6c0c50a049c51268c367ab4b880d59e39557efd42f28cfbe41640157c1e40d03"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-csv@1.14.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-csv/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-csv/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/CSV"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-csv.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.github.spotbugs/spotbugs-annotations@4.9.3?type=jar",
+      "group" : "com.github.spotbugs",
+      "name" : "spotbugs-annotations",
+      "version" : "4.9.3",
+      "description" : "Annotations the SpotBugs tool supports",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6149845e438bd5a34ebaf81f8bc9e243"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4d362bffcfdfd734999e94d7d98fde678aae71cf"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "13532bfe2f45fcd491432221df72d9cd0efb8f987c9245e12befa192c8925ce3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "78a74a014eafff94b16fdba52eac7e8a689cada2ef14d0c230412b904231d576cae49571aec95ea7ab9fb10d0defbc8b356007180320fcbc8b3635bd4b3be0b0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1cba6d4013aaad6bf620fb76b7eee278964771cee1d9b849ce5643728cdb75689a4e45c2278892f4379cb9c05d847ecc"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3cf6d8d62cab5806a08291b8459f480879bec229935f538dff421566fde135a617bf6d3629f4ca2a183068f4e8923c7d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "86fad9ff61ee413170b0368320c0a8cfab3e260ea054564b80ded970657876c3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0ceaddd802f486761a9fd11754f2adf3c8aac48289fc98a042b742131c7c6efb8f08771d6b169e3b6fdafb8e7a09882bc0f759a3c849d4dff919e0b7e8e33eab"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "LGPL-2.1-only"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.github.spotbugs/spotbugs-annotations@4.9.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spotbugs.github.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spotbugs/spotbugs/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+      "group" : "com.google.code.findbugs",
+      "name" : "jsr305",
+      "version" : "3.0.2",
+      "description" : "JSR305 Annotations for Findbugs",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dd83accb899363c32b07d7a1b2e4ce40"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bb09db62919a50fa5b55906013be6ca4fc7acb2e87455fac5eaf9ede2e41ce8bbafc0e5a385a561264ea4cd71bbbd3ef5a45e02d63277a201d06a0ae1636f804"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ca0b169d3eb2d0922dc031133a021f861a043bb3e405a88728215fd6ff00fa52fdc7347842dcc2031472e3726164bdc4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9903fd7505218999f8262efedb3d935d64bcef84aae781064ab5e1b24755466b269517cada562fa140cd1d417ede57a1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "223fda9a89a461afaae73b177a2dc20ed4a90f2f8757f5c65f3241b0510f00ff"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3996b5af57a5d5c6a0cd62b11773360fb051dd86a2ba968476806a2a5d32049b82d69a24a3c694e8fe4d735be6a28e41000cc500cc2a9fb577e058045855d2d6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://findbugs.sourceforge.net/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://code.google.com/p/jsr-305/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/junit/junit@4.13.2?type=jar",
+      "publisher" : "JUnit",
+      "group" : "junit",
+      "name" : "junit",
+      "version" : "4.13.2",
+      "description" : "JUnit is a unit testing framework for Java, created by Erich Gamma and Kent Beck.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d98a9a02a99a9acd22d7653cbcc1f31f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8ac9e16d933b6fb43bc7f576336b8f4d7eb5ba12"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a31b9950f929a7e5a600d89787ef40e42a8a8e2392e210d0c0f45b3572937670a18a524f1815508cd1152cd1eaa7275cb7430ba45c053be365c83c231bccd3f0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9f85c56a77c699eb87630b9e8224068a34c296bcd9aadb52248dd4665036f5bf1048fe75e5cb590b59e7855ca716acae"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "590cfd9396424583879ca8ad732870406bab18325ac72fb2bbe188b9611278d6341700badf7cfc32525b8ff42900c905"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a06b3fd2fd1d9f4306b58125484e3605a395afe5ffe2c801e43ae462f366a430"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a6d25ce3c14f9065f06dfd0e68e1dad5c03bd5de0a302c44ca4733d2cb87ec1bc6f0abd36d65aeee8caf328b6881432c4b682fa4b4b1fa931c3c950de5129fb2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0",
+            "url" : "http://www.eclipse.org/legal/epl-v10.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/junit/junit@4.13.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://junit.org"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/junit-team/junit4/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://github.com/junit-team/junit4/wiki/Download-and-Install"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/junit-team/junit4/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/junit-team/junit4"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar",
+      "group" : "org.hamcrest",
+      "name" : "hamcrest-core",
+      "version" : "1.3",
+      "description" : "This is the core API of hamcrest matcher framework to be used by third-party framework providers. This includes the a foundation set of matcher implementations for common operations.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6393363b47ddcbba82321110c3e07519"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "42a25dc3219429f0e5d060061f71acb49bf010a0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e237ae735aac4fa5a7253ec693191f42ef7ddce384c11d29fbf605981c0be077d086757409acad53cb5b9e53d86a07cc428d459ff0f5b00d32a8cbbca390be49"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4b5297d2a12cc32b824153afc83f1ba9f1869ca288330f0a2f759659d09e4c420eb6ba4a1efbfa0657b625edd41293d5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b14d34985c0a78cf0ba19b5a18bffd403e08adcb2afde228ddef6e16121c7046dbebf58c04d3419311c4496c48aa93be"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f679af77deedf69b3c3066f7916583848c6fd32a950f9c0b0e2ef1da121717ba"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bca821931e438a1977b7b4356b5f8cebf485634f82159d505c48267c34e6a0f4fde9c2917331365f66dc0e52e2ca3a2db5256863584110c27ecebefc28741f63"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+        }
+      ]
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.pqca/cbomkit-lib@1.0.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@3.0.0?type=jar",
+        "pkg:maven/org.slf4j/slf4j-simple@2.0.17?type=jar",
+        "pkg:maven/com.ibm/sonar-cryptography-plugin@1.4.5?type=jar",
+        "pkg:maven/org.sonarsource.api.plugin/sonar-plugin-api@12.0.0.2960?type=jar",
+        "pkg:maven/org.sonarsource.sonarqube/sonar-plugin-api-impl@25.6.0.109173?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@3.0.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/slf4j-simple@2.0.17?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@2.0.17?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/slf4j-api@2.0.17?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.ibm/sonar-cryptography-plugin@1.4.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.ibm/java@1.4.5?type=jar",
+        "pkg:maven/com.ibm/python@1.4.5?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+        "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+        "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.ibm/java@1.4.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.ibm/engine@1.4.5?type=jar",
+        "pkg:maven/com.ibm/output@1.4.5?type=jar",
+        "pkg:maven/com.ibm/enricher@1.4.5?type=jar",
+        "pkg:maven/com.ibm/rules@1.4.5?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+        "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+        "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.ibm/engine@1.4.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.ibm/common@1.4.5?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+        "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+        "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.ibm/common@1.4.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+        "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+        "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.errorprone/error_prone_annotations@2.36.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.errorprone/error_prone_annotations@2.36.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.java/java-surefire@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.java/java-frontend@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.java/java-checks@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.java/java-checks-aws@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.java/check-list@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.java/external-reports@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.java/java-jsp@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-commons@2.14.0.3087?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-xml-parsing@2.14.0.3087?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-performance-measure@2.14.0.3087?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.java/java-surefire@8.10.0.38194?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.java/java-frontend@8.10.0.38194?type=jar",
+        "pkg:maven/com.fasterxml.staxmate/staxmate@2.4.1?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-xml-parsing@2.14.0.3087?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.java/java-frontend@8.10.0.38194?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.java/jdt-package@1.3.0.89?type=jar",
+        "pkg:maven/org.sonarsource.sslr/sslr-core@1.24.0.633?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-commons@2.14.0.3087?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-regex-parsing@2.14.0.3087?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-performance-measure@2.14.0.3087?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.java/jdt-package@1.3.0.89?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.sslr/sslr-core@1.24.0.633?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-commons@2.14.0.3087?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-regex-parsing@2.14.0.3087?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-performance-measure@2.14.0.3087?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.staxmate/staxmate@2.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.codehaus.woodstox/stax2-api@3.1.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.codehaus.woodstox/stax2-api@3.1.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-xml-parsing@2.14.0.3087?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+        "pkg:maven/xerces/xercesImpl@2.12.2?type=jar",
+        "pkg:maven/xml-apis/xml-apis@1.4.01?type=jar",
+        "pkg:maven/com.fasterxml.woodstox/woodstox-core@6.4.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/xerces/xercesImpl@2.12.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/xml-apis/xml-apis@1.4.01?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/xml-apis/xml-apis@1.4.01?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.woodstox/woodstox-core@6.4.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.codehaus.woodstox/stax2-api@3.1.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.java/java-checks@8.10.0.38194?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.java/java-frontend@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.java/java-checks-common@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-recognizers@2.14.0.3087?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/org.springframework/spring-expression@6.1.13?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.java/java-checks-common@8.10.0.38194?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.java/java-frontend@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-recognizers@2.14.0.3087?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-recognizers@2.14.0.3087?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-expression@6.1.13?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@6.1.13?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-core@6.1.13?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-jcl@6.1.13?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-jcl@6.1.13?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.java/java-checks-aws@8.10.0.38194?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.java/java-frontend@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.java/java-checks-common@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-recognizers@2.14.0.3087?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.java/check-list@8.10.0.38194?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.java/java-checks@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.java/java-checks-aws@8.10.0.38194?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.java/external-reports@8.10.0.38194?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-commons@2.14.0.3087?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-xml-parsing@2.14.0.3087?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.java/java-jsp@8.10.0.38194?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.java/java-frontend@8.10.0.38194?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-jasper@9.0.96?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-jasper@9.0.96?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.96?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.96?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.96?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat/tomcat-annotations-api@9.0.96?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-annotations-api@9.0.96?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.96?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.python/python-frontend@4.26.0.19456?type=jar",
+        "pkg:maven/org.sonarsource.python/python-checks@4.26.0.19456?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-commons@2.14.0.3087?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-xml-parsing@2.14.0.3087?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-performance-measure@2.14.0.3087?type=jar",
+        "pkg:maven/commons-lang/commons-lang@2.6?type=jar",
+        "pkg:maven/org.codehaus.staxmate/staxmate@2.0.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.python/python-frontend@4.26.0.19456?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.sslr/sslr-core@1.24.0.633?type=jar",
+        "pkg:maven/com.google.guava/guava@32.1.3-jre?type=jar",
+        "pkg:maven/com.google.protobuf/protobuf-java@4.29.0?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-regex-parsing@2.14.0.3087?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-commons@2.14.0.3087?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.guava/guava@32.1.3-jre?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+        "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?type=jar",
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+        "pkg:maven/org.checkerframework/checker-qual@3.37.0?type=jar",
+        "pkg:maven/com.google.errorprone/error_prone_annotations@2.36.0?type=jar",
+        "pkg:maven/com.google.j2objc/j2objc-annotations@2.8?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.checkerframework/checker-qual@3.37.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.j2objc/j2objc-annotations@2.8?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.protobuf/protobuf-java@4.29.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.python/python-checks@4.26.0.19456?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.sonarsource.python/python-frontend@4.26.0.19456?type=jar",
+        "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+        "pkg:maven/org.sonarsource.analyzer-commons/sonar-analyzer-commons@2.14.0.3087?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/commons-lang/commons-lang@2.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.codehaus.staxmate/staxmate@2.0.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/stax/stax-api@1.0.1?type=jar",
+        "pkg:maven/org.codehaus.woodstox/stax2-api@3.1.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/stax/stax-api@1.0.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.guava/guava@32.1.3-jre?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.ibm/output@1.4.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.cyclonedx/cyclonedx-core-java@10.1.0?type=jar",
+        "pkg:maven/com.ibm/mapper@1.4.5?type=jar",
+        "pkg:maven/com.ibm/engine@1.4.5?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+        "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+        "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@10.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-codec/commons-codec@1.18.0?type=jar",
+        "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar",
+        "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar",
+        "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.18.2?type=jar",
+        "pkg:maven/com.networknt/json-schema-validator@1.5.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/commons-codec/commons-codec@1.18.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.18.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+        "pkg:maven/org.codehaus.woodstox/stax2-api@3.1.4?type=jar",
+        "pkg:maven/com.fasterxml.woodstox/woodstox-core@6.4.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.networknt/json-schema-validator@1.5.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.ethlo.time/itu@1.10.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.18.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.17?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.ethlo.time/itu@1.10.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.18.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+        "pkg:maven/org.yaml/snakeyaml@2.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.yaml/snakeyaml@2.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.ibm/mapper@1.4.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.ibm/engine@1.4.5?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+        "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+        "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.ibm/enricher@1.4.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.ibm/mapper@1.4.5?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+        "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+        "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.ibm/rules@1.4.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.ibm/mapper@1.4.5?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+        "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+        "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.ibm/python@1.4.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.ibm/engine@1.4.5?type=jar",
+        "pkg:maven/com.ibm/output@1.4.5?type=jar",
+        "pkg:maven/com.ibm/enricher@1.4.5?type=jar",
+        "pkg:maven/com.ibm/rules@1.4.5?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.12.1?type=jar",
+        "pkg:maven/org.sonarsource.java/sonar-java-plugin@8.10.0.38194?type=jar",
+        "pkg:maven/org.sonarsource.python/sonar-python-plugin@4.26.0.19456?type=jar",
+        "pkg:maven/com.google.googlejavaformat/google-java-format@1.25.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.api.plugin/sonar-plugin-api@12.0.0.2960?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@2.0.17?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.sonarsource.sonarqube/sonar-plugin-api-impl@25.6.0.109173?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-codec/commons-codec@1.18.0?type=jar",
+        "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/org.apache.commons/commons-csv@1.14.0?type=jar",
+        "pkg:maven/org.sonarsource.api.plugin/sonar-plugin-api@12.0.0.2960?type=jar",
+        "pkg:maven/com.github.spotbugs/spotbugs-annotations@4.9.3?type=jar",
+        "pkg:maven/junit/junit@4.13.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-csv@1.14.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.18.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.github.spotbugs/spotbugs-annotations@4.9.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/junit/junit@4.13.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.hamcrest/hamcrest-core@1.3?type=jar",
+      "dependsOn" : [ ]
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.pqca</groupId>
     <artifactId>cbomkit-lib</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/org/pqca/indexing/java/JavaIndexService.java
+++ b/src/main/java/org/pqca/indexing/java/JavaIndexService.java
@@ -36,8 +36,16 @@ public final class JavaIndexService extends IndexingService {
     public JavaIndexService(
             @Nullable IProgressDispatcher progressDispatcher, @Nonnull File baseDirectory) {
         super(progressDispatcher, baseDirectory, "java", ".java");
-        this.setFileExcluder(
-                f -> f.getPath().contains("src/test/") || f.getName().contains("package-info"));
+        this.setExcludePatterns(null);
+    }
+
+    public void setExcludePatterns(@Nullable List<String> patterns) {
+        if (patterns == null) {
+            super.setExcludePatterns(
+                    List.of("src/test/", "/package-info.java$", "/module-info.java$"));
+        } else {
+            super.setExcludePatterns(patterns);
+        }
     }
 
     @Override

--- a/src/main/java/org/pqca/indexing/python/PythonIndexService.java
+++ b/src/main/java/org/pqca/indexing/python/PythonIndexService.java
@@ -36,8 +36,15 @@ public final class PythonIndexService extends IndexingService {
     public PythonIndexService(
             @Nullable IProgressDispatcher progressDispatcher, @Nonnull File baseDirectory) {
         super(progressDispatcher, baseDirectory, "python", ".py");
-        this.setFileExcluder(
-                f -> f.getPath().contains("tests/") || f.getPath().contains("src/test/"));
+        this.setExcludePatterns(null);
+    }
+
+    public void setExcludePatterns(@Nullable List<String> patterns) {
+        if (patterns == null) {
+            super.setExcludePatterns(List.of("src/test/", "tests/"));
+        } else {
+            super.setExcludePatterns(patterns);
+        }
     }
 
     @Override

--- a/src/main/java/org/pqca/scanning/java/JavaScannerService.java
+++ b/src/main/java/org/pqca/scanning/java/JavaScannerService.java
@@ -122,7 +122,7 @@ public final class JavaScannerService extends ScannerService {
         if (!index.isEmpty() && (javaDependencyJars.isEmpty() && javaClassDirectories.isEmpty())) {
             if (this.requireBuild) {
                 throw new IllegalStateException(
-                        "No Java build artifacts found. Project must be build prior to scanning");
+                        "No Java build artifacts found. Project must be built prior to scanning");
             } else {
                 LOGGER.warn(
                         "No Java build artifacts found. Scanning Java code without prior build may produce less accurate CBOMs.");

--- a/src/test/java/org/pqca/indexing/JavaIndexServiceTest.java
+++ b/src/test/java/org/pqca/indexing/JavaIndexServiceTest.java
@@ -30,10 +30,17 @@ import org.sonar.api.batch.fs.InputFile;
 
 class JavaIndexServiceTest {
     @Test
+    void testExclusion() throws ClientDisconnected {
+        final JavaIndexService javaIndexService = new JavaIndexService(new File("."));
+        javaIndexService.setExcludePatterns(List.of("src/.*"));
+        final List<ProjectModule> projectModules = javaIndexService.index(null);
+        assertThat(projectModules).hasSize(0);
+    }
+
+    @Test
     void test() throws ClientDisconnected {
         final JavaIndexService javaIndexService =
                 new JavaIndexService(new File("src/test/testdata/java/keycloak"));
-        javaIndexService.setFileExcluder(f -> false);
         final List<ProjectModule> projectModules = javaIndexService.index(null);
         assertThat(projectModules).hasSize(2);
         for (ProjectModule projectModule : projectModules) {
@@ -49,7 +56,6 @@ class JavaIndexServiceTest {
     void plain() throws ClientDisconnected {
         final JavaIndexService javaIndexService =
                 new JavaIndexService(new File("src/test/testdata/java/plain"));
-        javaIndexService.setFileExcluder(f -> false);
         final List<ProjectModule> projectModules = javaIndexService.index(null);
         assertThat(projectModules).hasSize(1);
         final ProjectModule projectModule = projectModules.getFirst();
@@ -60,7 +66,6 @@ class JavaIndexServiceTest {
     void nested() throws ClientDisconnected {
         final JavaIndexService javaIndexService =
                 new JavaIndexService(new File("src/test/testdata/java/nested"));
-        javaIndexService.setFileExcluder(f -> false);
         final List<ProjectModule> projectModules = javaIndexService.index(null);
         assertThat(projectModules).hasSize(2);
         final ProjectModule projectModule1 = projectModules.getFirst();

--- a/src/test/java/org/pqca/indexing/PythonIndexServiceTest.java
+++ b/src/test/java/org/pqca/indexing/PythonIndexServiceTest.java
@@ -29,10 +29,16 @@ import org.pqca.indexing.python.PythonIndexService;
 
 class PythonIndexServiceTest {
     @Test
-    void test() throws ClientDisconnected {
-        final PythonIndexService pythonIndexService =
-                new PythonIndexService(new File("src/test/testdata/python/pyca"));
-        pythonIndexService.setFileExcluder(f -> false);
+    void testDefaultExclusion() throws ClientDisconnected {
+        final PythonIndexService pythonIndexService = new PythonIndexService(new File("."));
+        final List<ProjectModule> projectModules = pythonIndexService.index(null);
+        assertThat(projectModules).hasSize(0);
+    }
+
+    @Test
+    void testNoExclusion() throws ClientDisconnected {
+        final PythonIndexService pythonIndexService = new PythonIndexService(new File("."));
+        pythonIndexService.setExcludePatterns(List.of());
         final List<ProjectModule> projectModules = pythonIndexService.index(null);
         assertThat(projectModules).hasSize(1);
         final ProjectModule projectModule = projectModules.getFirst();

--- a/src/test/java/org/pqca/scanning/JavaScannerServiceTest.java
+++ b/src/test/java/org/pqca/scanning/JavaScannerServiceTest.java
@@ -20,7 +20,7 @@
 package org.pqca.scanning;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -38,7 +38,6 @@ class JavaScannerServiceTest {
     void test() throws ClientDisconnected {
         final File projectDirectory = new File("src/test/testdata/java/keycloak");
         final JavaIndexService javaIndexService = new JavaIndexService(projectDirectory);
-        javaIndexService.setFileExcluder(f -> false);
         // indexing
         final List<ProjectModule> projectModules = javaIndexService.index(null);
         assertThat(projectModules).hasSize(2);
@@ -162,29 +161,21 @@ class JavaScannerServiceTest {
     void testRequireBuildException() throws ClientDisconnected {
         final File projectDirectory = new File("src/test/testdata/java/plain");
         final JavaIndexService javaIndexService = new JavaIndexService(projectDirectory);
-        javaIndexService.setFileExcluder(f -> false);
 
         final List<ProjectModule> projectModules = javaIndexService.index(null);
         final JavaScannerService javaScannerService = new JavaScannerService(projectDirectory);
         javaScannerService.setRequireBuild(true);
 
-        IllegalStateException exception =
-                assertThrows(
-                        IllegalStateException.class,
-                        () -> javaScannerService.scan(projectModules),
-                        "Expected IllegalStateException");
-        assertThat(
-                exception
-                        .getMessage()
-                        .equals(
-                                "No Java build artifacts found. Project must be build prior to scanning"));
+        assertThatIllegalStateException()
+                .isThrownBy(() -> javaScannerService.scan(projectModules))
+                .withMessage(
+                        "No Java build artifacts found. Project must be built prior to scanning");
     }
 
     @Test
     void testRequireBuildTrue() throws ClientDisconnected {
         final File projectDirectory = new File("src/test/testdata/java/plain");
         final JavaIndexService javaIndexService = new JavaIndexService(projectDirectory);
-        javaIndexService.setFileExcluder(f -> false);
 
         final List<ProjectModule> projectModules = javaIndexService.index(null);
         final JavaScannerService javaScannerService = new JavaScannerService(projectDirectory);
@@ -201,7 +192,6 @@ class JavaScannerServiceTest {
     void testRequireBuildFalse() throws ClientDisconnected {
         final File projectDirectory = new File("src/test/testdata/java/plain");
         final JavaIndexService javaIndexService = new JavaIndexService(projectDirectory);
-        javaIndexService.setFileExcluder(f -> false);
 
         final List<ProjectModule> projectModules = javaIndexService.index(null);
         final JavaScannerService javaScannerService = new JavaScannerService(projectDirectory);

--- a/src/test/java/org/pqca/scanning/PythonScannerServiceTest.java
+++ b/src/test/java/org/pqca/scanning/PythonScannerServiceTest.java
@@ -37,7 +37,6 @@ class PythonScannerServiceTest {
         // indexing
         final File projectDirectory = new File("src/test/testdata/python/pyca");
         final PythonIndexService pythonIndexService = new PythonIndexService(projectDirectory);
-        pythonIndexService.setFileExcluder(f -> false);
         final List<ProjectModule> projectModules = pythonIndexService.index(null);
         assertThat(projectModules).hasSize(1);
         final ProjectModule projectModule = projectModules.getFirst();


### PR DESCRIPTION
PR for issue [#29](https://github.com/orgs/PQCA/projects/2/views/1?pane=issue&itemId=113775689&issue=PQCA%7Ccbomkit-action%7C29)

- Replaced exclusion predicate with customizable patterns
- Matching is performed on relative paths w.r.t project directory
- Exclude file/dir from indexing if any pattern matches
- `<indexer>.setExclusionPatterns(List<String> patterns)` sets patterns
   - Patterns are java regexes that match on the first occurrence
   - Default patterns
      - Python `src/test/`, `tests/`
      - Java `src/test/`, `/package-info.java$`, `/module-info.java$`
   - Passing `null` -> re-establish default
   - Passing empty list means no exclusion -> index everything