### PR TITLE
Upgrade to sonar-cryptography 1.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <sonar.crypto.plugin.version>1.4.6</sonar.crypto.plugin.version>
+        <sonar.crypto.plugin.version>1.4.7</sonar.crypto.plugin.version>
         <sonar.plugin.api.version>13.0.0.3026</sonar.plugin.api.version>
         <sonar.plugin.api.impl.version>25.8.0.112029</sonar.plugin.api.impl.version>
 

--- a/src/main/java/org/pqca/scanning/java/JavaScannerService.java
+++ b/src/main/java/org/pqca/scanning/java/JavaScannerService.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.pqca.errors.ClientDisconnected;
 import org.pqca.indexing.ProjectModule;
 import org.pqca.progress.IProgressDispatcher;
@@ -36,16 +37,20 @@ import org.pqca.scanning.ScanResultDTO;
 import org.pqca.scanning.ScannerService;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultFileSystem;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.java.DefaultJavaResourceLocator;
 import org.sonar.java.JavaFrontend;
+import org.sonar.java.Measurer;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.classpath.ClasspathForMain;
 import org.sonar.java.classpath.ClasspathForTest;
 import org.sonar.java.model.JavaVersionImpl;
+import org.sonar.java.telemetry.NoOpTelemetry;
 import org.sonar.plugins.java.api.JavaResourceLocator;
 import org.sonar.plugins.java.api.JavaVersion;
 
@@ -154,7 +159,8 @@ public final class JavaScannerService extends ScannerService {
                 new JavaFrontend(
                         JAVA_VERSION,
                         sonarComponents,
-                        null,
+                        getMeasurer(sensorContext),
+                        new NoOpTelemetry(),
                         javaResourceLocator,
                         null,
                         new JavaDetectionCollectionRule(this));
@@ -220,6 +226,18 @@ public final class JavaScannerService extends ScannerService {
                 classpathForTest,
                 null,
                 null);
+    }
+
+    @Nonnull
+    private static Measurer getMeasurer(SensorContext context) {
+        return new Measurer(
+                context,
+                new NoSonarFilter() {
+                    @Override
+                    public NoSonarFilter noSonarInFile(InputFile arg0, Set<Integer> arg1) {
+                        return null;
+                    }
+                });
     }
 
     // private String findClassDirs() {

--- a/src/main/java/org/pqca/scanning/python/PythonScannerService.java
+++ b/src/main/java/org/pqca/scanning/python/PythonScannerService.java
@@ -76,11 +76,10 @@ public final class PythonScannerService extends ScannerService {
                 final PythonScannableFile pythonScannableFile = new PythonScannableFile(inputFile);
                 final FileInput parsedFile = pythonScannableFile.parse();
                 final PythonVisitorContext context =
-                        new PythonVisitorContext(
-                                parsedFile,
-                                pythonScannableFile,
-                                this.projectDirectory,
-                                project.identifier());
+                        new PythonVisitorContext.Builder(parsedFile, pythonScannableFile)
+                                .workingDirectory(this.projectDirectory)
+                                .packageName(project.identifier())
+                                .build();
                 visitor.scanFile(context);
             }
             counter++;


### PR DESCRIPTION
sonar-cryptography 1.4.7 is based on sonar-java 8.18.0.40025 and sonar-python 5.8.0.24785. This required adaptation of `JavaScannerService.java` and `PythonScannerService.java`.