### PR TITLE
Bump asserj-core to 3.27.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.27.6</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Avoids XML External Entity (XXE) vulnerability.